### PR TITLE
요일 버튼과 요일 전체 컴포넌트

### DIFF
--- a/one-day-hero/src/components/common/Day/DayButton.tsx
+++ b/one-day-hero/src/components/common/Day/DayButton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState } from "react";
+
+const DayButton = ({
+  children,
+  className
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+  const [clicked, setClicked] = useState<boolean>(false);
+
+  const handleDayClick = () => {
+    setClicked(!clicked);
+  };
+
+  const defaultStyle = "w-11 h-11 text-base rounded-lg border";
+
+  return (
+    <button
+      className={`${defaultStyle} ${
+        clicked
+          ? "border-4 border-lime-200 bg-lime-100"
+          : "border-zinc-300 bg-white"
+      } ${className}`}
+      onClick={handleDayClick}>
+      {children}
+    </button>
+  );
+};
+
+export default DayButton;

--- a/one-day-hero/src/components/common/Day/DayList.tsx
+++ b/one-day-hero/src/components/common/Day/DayList.tsx
@@ -1,0 +1,14 @@
+import DayButton from "./DayButton";
+
+const DayList = () => {
+  const days = ["월", "화", "수", "목", "금", "토", "일"];
+  return (
+    <div className="flex gap-x-1.5">
+      {days.map((day, index) => (
+        <DayButton key={index}>{day}</DayButton>
+      ))}
+    </div>
+  );
+};
+
+export default DayList;

--- a/one-day-hero/src/components/common/Day/DayList.tsx
+++ b/one-day-hero/src/components/common/Day/DayList.tsx
@@ -2,6 +2,7 @@ import DayButton from "./DayButton";
 
 const DayList = () => {
   const days = ["월", "화", "수", "목", "금", "토", "일"];
+
   return (
     <div className="flex gap-x-1.5">
       {days.map((day, index) => (

--- a/one-day-hero/src/components/common/Label.tsx
+++ b/one-day-hero/src/components/common/Label.tsx
@@ -1,3 +1,5 @@
+import { PropsWithChildren } from "react";
+
 interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
   size?: "sm" | "md" | "lg";
 }
@@ -7,7 +9,7 @@ const Label = ({
   children,
   className = "",
   ...props
-}: LabelProps) => {
+}: PropsWithChildren<LabelProps>) => {
   const sizes = {
     sm: "text-xs min-w-16 h-4 px-4 rounded-3xl",
     md: "text-sm min-w-28 h-6 px-3 rounded-3xl",


### PR DESCRIPTION
## 구현 내용
요일 버튼과 요일 전체 컴포넌트 생성했습니다. 
나머지 로직은 api가 연결되면 수정 할 것 같습니다. 

`<DayList/>` 넣어서 사용하시면 됩니다. 
## 스크린샷

https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/99384699/0adaa8d2-af3f-473d-a544-ccac647019cc

## 궁금한 점
더 좋은 방법이 있는 지 궁금합니다. 
## 이슈번호
- closes #
