### PR TITLE
39 히어로 지수

### DIFF
--- a/one-day-hero/src/app/page.tsx
+++ b/one-day-hero/src/app/page.tsx
@@ -13,6 +13,7 @@ const HomePage = () => {
       <div className="w-96 p-5">
         <MissionListItem />
         <HeroScore score={20} />
+        <HeroScore size="sm" score={50} />
       </div>
       <DayList />
       <Button />

--- a/one-day-hero/src/app/page.tsx
+++ b/one-day-hero/src/app/page.tsx
@@ -4,6 +4,7 @@ import MissionListItem from "@/components/common/MissionListItem";
 import Button from "@/components/common/Button";
 import DayList from "@/components/common/Day/DayList";
 import Label from "@/components/common/Label";
+import HeroScore from "@/components/common/HeroScore";
 
 const HomePage = () => {
   return (
@@ -11,6 +12,7 @@ const HomePage = () => {
       <div>HomePage</div>
       <div className="w-96 p-5">
         <MissionListItem />
+        <HeroScore score={20} />
       </div>
       <DayList />
       <Button />

--- a/one-day-hero/src/components/common/HeroScore.tsx
+++ b/one-day-hero/src/components/common/HeroScore.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+
+const VILLAIN_MAX_SCORE = 20;
+const HERO_INITAIL_SCORE = 30;
+
+interface HeroScoreProps extends React.ComponentProps<"div"> {
+  size?: "sm" | "lg";
+  score: number;
+}
+
+const HeroScore = ({
+  size = "lg",
+  score = HERO_INITAIL_SCORE,
+  className = "",
+  ...props
+}: HeroScoreProps) => {
+  const isHero = score > VILLAIN_MAX_SCORE;
+  const guageLevel = Math.ceil((score * 12) / 100);
+
+  const sizes = {
+    sm: "text-sm h-3 rounded-md",
+    lg: "text-lg h-6 rounded-xl"
+  };
+
+  const guageWidth = [
+    "w-0",
+    "w-1/12",
+    "w-2/12",
+    "w-3/12",
+    "w-4/12",
+    "w-5/12",
+    "w-6/12",
+    "w-7/12",
+    "w-8/12",
+    "w-9/12",
+    "w-10/12",
+    "w-11/12",
+    "w-full"
+  ];
+
+  const guageColor = isHero ? "bg-sub" : "bg-bad";
+
+  return (
+    <div
+      className={`${sizes[size]} ${className} flex w-full items-center bg-base-darken`}
+      {...props}>
+      <div
+        className={`${sizes[size]} ${guageColor} ${guageWidth[guageLevel]} flex flex-row-reverse items-center`}>
+        {size === "lg" && isHero && (
+          <p className={`mr-2 text-white`}>{score} 점</p>
+        )}
+      </div>
+      {size === "lg" && !isHero && (
+        <p className={`ml-1 font-semibold text-bad`}>{score} 점</p>
+      )}
+    </div>
+  );
+};
+
+export default HeroScore;

--- a/one-day-hero/src/components/common/HeroScore.tsx
+++ b/one-day-hero/src/components/common/HeroScore.tsx
@@ -21,7 +21,6 @@ const HeroScore = ({
     sm: "text-sm h-3 rounded-md",
     lg: "text-lg h-6 rounded-xl"
   };
-
   const guageWidth = [
     "w-0",
     "w-1/12",
@@ -37,22 +36,25 @@ const HeroScore = ({
     "w-11/12",
     "w-full"
   ];
-
   const guageColor = isHero ? "bg-sub" : "bg-bad";
+  const textColor = isHero ? "text-sub" : "text-bad";
 
   return (
-    <div
-      className={`${sizes[size]} ${className} flex w-full items-center bg-base-darken`}
-      {...props}>
+    <div className={`${className} flex flex-col`}>
+      {size === "sm" && <p className={`${textColor} text-right`}>{score} 점</p>}
       <div
-        className={`${sizes[size]} ${guageColor} ${guageWidth[guageLevel]} flex flex-row-reverse items-center`}>
-        {size === "lg" && isHero && (
-          <p className={`mr-2 text-white`}>{score} 점</p>
+        className={`${sizes[size]} flex grow items-center bg-base-darken`}
+        {...props}>
+        <div
+          className={`${sizes[size]} ${guageColor} ${guageWidth[guageLevel]} flex flex-row-reverse items-center`}>
+          {size === "lg" && isHero && (
+            <p className={`mr-2 text-white`}>{score} 점</p>
+          )}
+        </div>
+        {size === "lg" && !isHero && (
+          <p className={`ml-1 font-semibold text-bad`}>{score} 점</p>
         )}
       </div>
-      {size === "lg" && !isHero && (
-        <p className={`ml-1 font-semibold text-bad`}>{score} 점</p>
-      )}
     </div>
   );
 };

--- a/one-day-hero/tailwind.config.ts
+++ b/one-day-hero/tailwind.config.ts
@@ -22,7 +22,8 @@ const config: Config = {
         sub: {
           DEFAULT: "#FF8551",
           lighten: "#FFAA7A",
-          darken: "#D77247"
+          darken: "#D77247",
+          lightest: "#FFE6CF"
         },
         active: {
           DEFAULT: "#EB6A4E",
@@ -38,7 +39,8 @@ const config: Config = {
           DEFAULT: "#D8D8D8",
           lighten: "#EFEFEF",
           darken: "#939393"
-        }
+        },
+        bad: "#A990C1"
       },
       boxShadow: {
         upper: "0px -2px 5px rgba(0, 0, 0, 0.07)",


### PR DESCRIPTION
## 구현 내용
- 프로필이나 유저 버튼에 나올 히어로 지수 컴포넌트를 구현했습니다.
- 빌런 색깔을 tailwind.config.js에 추가하고 `sub-lightest` 색상도 토글버튼에서 쓸 것 같아서 추가했습니다.
- 게이지 너비 조정을 위해 `guageWidth` 객체를 사용했습니다.

## 스크린샷
<img width="272" alt="image" src="https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/54025398/6e407766-e16c-4a8e-8695-23e02f2de1f5">

## 궁금한 점
일단 테일윈드 기본 상대 너비 쓰려고 너비를 12단계로 나눠서만 적용했는데 더 세세하게 적용할 필요도 있을까요?

## 이슈번호
- closes #39 
