### PR TITLE
미션 생성 Mock 데이터 테스트

### DIFF
--- a/one-day-hero/src/app/api/v1/mock/missions/create/route.ts
+++ b/one-day-hero/src/app/api/v1/mock/missions/create/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { Response } from "@/app/mission/create/page";
+
+export async function POST(request: NextRequest) {
+  const {
+    missionInfo,
+    missionCategoryId,
+    citizenId,
+    regionId,
+    latitude,
+    longitude
+  } = await request.json();
+
+  const formatData: Response = {
+    data: {
+      id: 1,
+      missionCategory: {
+        categoryId: missionCategoryId,
+        code: "MC_001",
+        name: "서빙"
+      },
+      citizenId,
+      regionId,
+      location: {
+        x: latitude,
+        y: longitude
+      },
+      missionInfo,
+      bookmarkCount: 0,
+      missionStatus: "MATCHING"
+    }
+  };
+
+  return NextResponse.json(formatData, { status: 201 });
+}

--- a/one-day-hero/src/app/mission/create/page.tsx
+++ b/one-day-hero/src/app/mission/create/page.tsx
@@ -1,9 +1,64 @@
 import Category from "@/components/common/Category";
+import { apiUrl } from "@/services/urls";
 
-const MissionCreatePage = () => {
+const dummy = {
+  missionCategoryId: 1,
+  citizenId: 1,
+  regionId: 1,
+  latitude: 1234252.23,
+  longitude: 1234277.388,
+  missionInfo: {
+    content: "내용",
+    missionDate: "2023-10-10",
+    startTime: "10:00",
+    endTime: "10:30",
+    deadlineTime: "10:00",
+    price: 10000
+  }
+};
+
+export type Response = {
+  data: {
+    id: number;
+    missionCategory: {
+      categoryId: number;
+      code: string;
+      name: string;
+    };
+    citizenId: number;
+    regionId: number;
+    location: {
+      x: number;
+      y: number;
+    };
+    missionInfo: {
+      content: string;
+      missionDate: string;
+      startTime: string;
+      endTime: string;
+      deadlineTime: string;
+      price: number;
+    };
+    bookmarkCount: number;
+    missionStatus: string;
+  };
+};
+
+const MissionCreatePage = async () => {
+  const response = await fetch(apiUrl("/missions/create"), {
+    method: "POST",
+    body: JSON.stringify(dummy)
+  });
+
+  const { data }: Response = await response.json();
+
+  const { id, missionInfo } = data;
+
   return (
     <div className="w-full">
       <Category />
+      <h1>{id}</h1>
+      <span>{missionInfo.price}</span>
     </div>
   );
 };


### PR DESCRIPTION
## 구현 내용
- 미션 생성에 관한 POST 요청을 보낸 후 명세서에 맞는 응답을 내려주도록 테스트 해보았습니다.

## 스크린샷
![image](https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/117630589/6e25212f-3779-4898-8c1f-bf5b7522c086)

위 스크린샷은 응답을 받아와서 잘 사용할 수 있는지 테스트 한 부분입니다.

## 궁금한 점
- 일단은 주어진 정보가 적어서 더미를 받아오는 것처럼 구현했는데 잘 한건지 모르겠네요..
- type과 dummy로 보내는 요청은 생성 페이지 양식에 맞게 삭제 후 진행할 예정입니다.

## 이슈번호
- closes #80 
