### PR TITLE
이미지 업로드 컴포넌트 구현

### DIFF
--- a/one-day-hero/src/components/common/UploadImage.tsx
+++ b/one-day-hero/src/components/common/UploadImage.tsx
@@ -19,9 +19,6 @@ const UploadImage = ({
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const handleUpload = () => {
-    if (selectedImages && size === "md") {
-      return;
-    }
     inputRef?.current?.click();
   };
 
@@ -51,16 +48,16 @@ const UploadImage = ({
   };
 
   const defaultStyle =
-    "rounded-2xl bg-inactive text-white flex justify-center items-center shrink-0";
+    "bg-inactive text-white flex justify-center items-center shrink-0";
 
   const sizes = {
-    md: "w-32 h-32 text-4xl",
-    lg: "w-52 h-52 text-5xl relative"
+    md: "w-32 h-32 text-4xl rounded-[10px]",
+    lg: "w-52 h-52 text-5xl relative rounded-2xl"
   };
 
   const imageSizes = {
-    md: "w-32 h-32 relative duration-300 hover:scale-105 text-2xl",
-    lg: "w-52 h-52 absolute overflow-hidden text-3xl"
+    md: "w-32 h-32 relative duration-300 hover:scale-105 text-2xl rounded-[10px]",
+    lg: "w-52 h-52 absolute overflow-hidden text-3xl rounded-2xl"
   };
 
   return (
@@ -92,8 +89,8 @@ const UploadImage = ({
           selectedImages.map((image) => (
             <div
               key={image.name}
-              onClick={handleUpload}
-              className={`${imageSizes[size]} shrink-0 overflow-hidden rounded-2xl`}>
+              onClick={size === "lg" ? handleUpload : undefined}
+              className={`${imageSizes[size]} shrink-0 overflow-hidden`}>
               <BiX
                 className="absolute right-3 top-3 z-10 flex text-black"
                 onClick={handleDelete}

--- a/one-day-hero/src/components/common/UploadImage.tsx
+++ b/one-day-hero/src/components/common/UploadImage.tsx
@@ -23,6 +23,7 @@ const UploadImage = ({
   };
 
   const handleDelete = (e: MouseEvent) => {
+    // 추후 구현 예정
     e.stopPropagation();
   };
 

--- a/one-day-hero/src/components/common/UploadImage.tsx
+++ b/one-day-hero/src/components/common/UploadImage.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import Image from "next/image";
+import { ChangeEvent, PropsWithChildren, useRef, useState } from "react";
+import { BiCamera, BiX } from "react-icons/bi";
+
+import HorizontalScroll from "./HorizontalScroll";
+
+interface UploadImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  size?: "md" | "lg";
+}
+
+const UploadImage = ({
+  size = "md",
+  className = "",
+  ...props
+}: PropsWithChildren<UploadImageProps>) => {
+  const [selectedImages, setSelectedImages] = useState<File[] | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleUpload = () => {
+    if (selectedImages && size === "md") {
+      return;
+    }
+    inputRef?.current?.click();
+  };
+
+  const handleDelete = (e: MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  const handleFileSelect = (event: ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files) {
+      if (size === "md") {
+        if (
+          event.target.files.length > 3 ||
+          (selectedImages && selectedImages.length >= 3)
+        ) {
+          alert("사진은 최대 3장입니다.");
+          return;
+        }
+        const newFile = Array.from(event.target.files);
+        setSelectedImages((prev) =>
+          prev ? [...prev, ...newFile] : [...newFile]
+        );
+      } else {
+        const newFile = Array.from(event.target.files);
+        setSelectedImages(newFile);
+      }
+    }
+  };
+
+  const defaultStyle =
+    "rounded-2xl bg-inactive text-white flex justify-center items-center shrink-0";
+
+  const sizes = {
+    md: "w-32 h-32 text-4xl",
+    lg: "w-52 h-52 text-5xl relative"
+  };
+
+  const imageSizes = {
+    md: "w-32 h-32 relative duration-300 hover:scale-105 text-2xl",
+    lg: "w-52 h-52 absolute overflow-hidden text-3xl"
+  };
+
+  return (
+    <HorizontalScroll>
+      <div
+        className={`flex w-full flex-nowrap overflow-auto ${
+          size === "md" ? "flex-row gap-2" : ""
+        }`}>
+        <div
+          className={`${defaultStyle} ${sizes[size]} ${className}`}
+          {...props}
+          onClick={handleUpload}>
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleFileSelect}
+            multiple={size === "md"}
+          />
+          <div className="flex flex-col items-center justify-center">
+            <BiCamera />
+            {size === "md" && (
+              <p className="text-base">{selectedImages?.length ?? "0"} / 3</p>
+            )}
+          </div>
+        </div>
+        {selectedImages &&
+          selectedImages.map((image) => (
+            <div
+              key={image.name}
+              onClick={handleUpload}
+              className={`${imageSizes[size]} shrink-0 overflow-hidden rounded-2xl`}>
+              <BiX
+                className="absolute right-3 top-3 z-10 flex text-black"
+                onClick={handleDelete}
+              />
+              <Image
+                src={URL.createObjectURL(image)}
+                alt="올린 이미지"
+                fill
+                className="bg-cover"
+              />
+            </div>
+          ))}
+      </div>
+    </HorizontalScroll>
+  );
+};
+
+export default UploadImage;


### PR DESCRIPTION
## 구현 내용
이미지 업로드 컴포넌트를 구현합니다.
- 기본 default 사이즈는 md 사이즈로 미션 이미지 업로드 용이며 최대 3개까지 선택 가능합니다.
- `<UploadImage size='lg' />` 로 쓰시면 1개만 업로드 가능한 프로필 용 업로드 컴포넌트가 됩니다.
- delete 부분은 비교할 부분이 아직 애매해서 추후 구현 예정입니다.

## 스크린샷
- md 사이즈

https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/117630589/8d24626c-0323-4286-a54f-7dbc21dab91c

- lg 사이즈

https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/117630589/48fab751-e397-4a08-b7df-95d64395fb43


## 궁금한 점

## 이슈번호
- closes #82 
