### PR TITLE
미션 생성 페이지

### DIFF
--- a/one-day-hero/src/app/api/v1/mock/missions/create/route.ts
+++ b/one-day-hero/src/app/api/v1/mock/missions/create/route.ts
@@ -1,36 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { Response } from "@/app/mission/create/page";
-
 export async function POST(request: NextRequest) {
-  const {
-    missionInfo,
-    missionCategoryId,
-    citizenId,
-    regionId,
-    latitude,
-    longitude
-  } = await request.json();
+  const { categoryId, missionInfo } = await request.json();
 
-  const formatData: Response = {
-    data: {
-      id: 1,
-      missionCategory: {
-        categoryId: missionCategoryId,
-        code: "MC_001",
-        name: "서빙"
-      },
-      citizenId,
-      regionId,
-      location: {
-        x: latitude,
-        y: longitude
-      },
-      missionInfo,
-      bookmarkCount: 0,
-      missionStatus: "MATCHING"
-    }
-  };
+  console.log("categoryId:", categoryId);
+  console.log("missionInfo:", missionInfo);
 
-  return NextResponse.json(formatData, { status: 201 });
+  return NextResponse.json(missionInfo, { status: 201 });
 }

--- a/one-day-hero/src/app/mission/create/layout.tsx
+++ b/one-day-hero/src/app/mission/create/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import FooterButton from "@/components/common/FooterButton";
 import Header from "@/components/common/Header";
 
 const layout = ({ children }: { children: React.ReactNode }) => {
@@ -7,6 +8,7 @@ const layout = ({ children }: { children: React.ReactNode }) => {
     <>
       <Header>미션 생성</Header>
       {children}
+      <FooterButton formId="missionCreateForm">생성하기</FooterButton>
     </>
   );
 };

--- a/one-day-hero/src/app/mission/create/layout.tsx
+++ b/one-day-hero/src/app/mission/create/layout.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-import Footer from "@/components/common/Footer";
 import Header from "@/components/common/Header";
 
 const layout = ({ children }: { children: React.ReactNode }) => {
@@ -8,7 +7,6 @@ const layout = ({ children }: { children: React.ReactNode }) => {
     <>
       <Header>미션 생성</Header>
       {children}
-      <Footer />
     </>
   );
 };

--- a/one-day-hero/src/app/mission/create/page.tsx
+++ b/one-day-hero/src/app/mission/create/page.tsx
@@ -1,64 +1,9 @@
-import Category from "@/components/common/Category";
-import { apiUrl } from "@/services/urls";
+import CreateForm from "@/components/domain/mission/create/CreateForm";
 
-const dummy = {
-  missionCategoryId: 1,
-  citizenId: 1,
-  regionId: 1,
-  latitude: 1234252.23,
-  longitude: 1234277.388,
-  missionInfo: {
-    content: "내용",
-    missionDate: "2023-10-10",
-    startTime: "10:00",
-    endTime: "10:30",
-    deadlineTime: "10:00",
-    price: 10000
-  }
-};
-
-export type Response = {
-  data: {
-    id: number;
-    missionCategory: {
-      categoryId: number;
-      code: string;
-      name: string;
-    };
-    citizenId: number;
-    regionId: number;
-    location: {
-      x: number;
-      y: number;
-    };
-    missionInfo: {
-      content: string;
-      missionDate: string;
-      startTime: string;
-      endTime: string;
-      deadlineTime: string;
-      price: number;
-    };
-    bookmarkCount: number;
-    missionStatus: string;
-  };
-};
-
-const MissionCreatePage = async () => {
-  const response = await fetch(apiUrl("/missions/create"), {
-    method: "POST",
-    body: JSON.stringify(dummy)
-  });
-
-  const { data }: Response = await response.json();
-
-  const { id, missionInfo } = data;
-
+const MissionCreatePage = () => {
   return (
-    <div className="w-full">
-      <Category />
-      <h1>{id}</h1>
-      <span>{missionInfo.price}</span>
+    <div className="flex w-full flex-col items-center">
+      <CreateForm />
     </div>
   );
 };

--- a/one-day-hero/src/components/common/Category.tsx
+++ b/one-day-hero/src/components/common/Category.tsx
@@ -12,6 +12,7 @@ import {
 
 import IconGroup from "@/components/common/IconGroup";
 
+import ErrorMessage from "../domain/mission/create/ErrorMessage";
 import HorizontalScroll from "./HorizontalScroll";
 
 const categories = [
@@ -25,11 +26,14 @@ const categories = [
   { icon: <BiStar />, title: "기타" }
 ];
 
-interface CategoryProps extends React.ComponentProps<"div"> {
+type CategoryProps = {
   isRoute?: boolean;
-}
+  error?: string;
+  // eslint-disable-next-line no-unused-vars
+  onSelect?: (idx: number) => void;
+};
 
-const Category = ({ isRoute = false }: CategoryProps) => {
+const Category = ({ isRoute = false, error, onSelect }: CategoryProps) => {
   const [activeState, setActiveState] = useState<boolean[]>(
     Array(categories.length).fill(false)
   );
@@ -39,10 +43,13 @@ const Category = ({ isRoute = false }: CategoryProps) => {
     "flex-shrink-0 select-none flex justify-center items-center cursor-pointer bg-white w-16 h-16 rounded-3xl shadow";
 
   const handleClick = (index: number) => {
-    if (!isRoute) {
-      setActiveState(
-        activeState.map((active, idx) => idx === index && !active)
+    if (!isRoute && onSelect) {
+      const newActiveState = activeState.map(
+        (active, idx) => idx === index && !active
       );
+      setActiveState(newActiveState);
+      const categoryId = newActiveState.findIndex((category) => category) + 1;
+      onSelect(categoryId);
     } else {
       // url 구조 따라 link 추가 예정
       console.log("link");
@@ -63,6 +70,7 @@ const Category = ({ isRoute = false }: CategoryProps) => {
           </div>
         ))}
       </ul>
+      {error && <ErrorMessage>{error}</ErrorMessage>}
     </HorizontalScroll>
   );
 };

--- a/one-day-hero/src/components/common/Category.tsx
+++ b/one-day-hero/src/components/common/Category.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { BiDish, BiGift, BiStar } from "react-icons/bi";
 import { CgSmartHomeRefrigerator } from "react-icons/cg";
 import {
@@ -34,27 +34,38 @@ type CategoryProps = {
 };
 
 const Category = ({ isRoute = false, error, onSelect }: CategoryProps) => {
-  const [activeState, setActiveState] = useState<boolean[]>(
+  const [categoryActiveState, setCategoryActiveState] = useState<boolean[]>(
     Array(categories.length).fill(false)
   );
+  const [errorState, setErrorState] = useState<boolean>(false);
 
   const containerStyle = "flex gap-3";
+
   const itemStyle =
     "flex-shrink-0 select-none flex justify-center items-center cursor-pointer bg-white w-16 h-16 rounded-3xl shadow";
 
   const handleClick = (index: number) => {
     if (!isRoute && onSelect) {
-      const newActiveState = activeState.map(
+      const newActiveState = categoryActiveState.map(
         (active, idx) => idx === index && !active
       );
-      setActiveState(newActiveState);
+
+      setCategoryActiveState(newActiveState);
+
       const categoryId = newActiveState.findIndex((category) => category) + 1;
+
       onSelect(categoryId);
+
+      errorState && setErrorState(false);
     } else {
       // url 구조 따라 link 추가 예정
       console.log("link");
     }
   };
+
+  useEffect(() => {
+    error && setErrorState(true);
+  }, [error]);
 
   return (
     <HorizontalScroll>
@@ -62,7 +73,9 @@ const Category = ({ isRoute = false, error, onSelect }: CategoryProps) => {
         {categories.map((category, index) => (
           <div
             key={index}
-            className={`${itemStyle} ${activeState[index] && "cs:bg-primary"}`}
+            className={`${itemStyle} ${
+              categoryActiveState[index] && "cs:bg-primary"
+            }`}
             onClick={() => handleClick(index)}>
             <IconGroup title={category.title} textSize="sm">
               {category.icon}
@@ -70,7 +83,7 @@ const Category = ({ isRoute = false, error, onSelect }: CategoryProps) => {
           </div>
         ))}
       </ul>
-      {error && <ErrorMessage>{error}</ErrorMessage>}
+      {error && errorState && <ErrorMessage>{error}</ErrorMessage>}
     </HorizontalScroll>
   );
 };

--- a/one-day-hero/src/components/common/FooterButton.tsx
+++ b/one-day-hero/src/components/common/FooterButton.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from "react";
+
+import Button from "./Button";
+
+const FooterButton = ({ children }: PropsWithChildren) => {
+  const defaultStyle =
+    "bg-background shadow-upper flex h-14 max-w-screen-sm w-full items-center justify-center fixed bottom-0";
+
+  return (
+    <div className={`${defaultStyle}`}>
+      <Button className="cs:h-11" type="submit">
+        {children}
+      </Button>
+    </div>
+  );
+};
+
+export default FooterButton;

--- a/one-day-hero/src/components/common/FooterButton.tsx
+++ b/one-day-hero/src/components/common/FooterButton.tsx
@@ -2,13 +2,20 @@ import { PropsWithChildren } from "react";
 
 import Button from "./Button";
 
-const FooterButton = ({ children }: PropsWithChildren) => {
+type FooterButtonProps = {
+  formId?: string;
+};
+
+const FooterButton = ({
+  formId,
+  children
+}: PropsWithChildren<FooterButtonProps>) => {
   const defaultStyle =
     "bg-background shadow-upper flex h-14 max-w-screen-sm w-full items-center justify-center fixed bottom-0";
 
   return (
     <div className={`${defaultStyle}`}>
-      <Button className="cs:h-11" type="submit">
+      <Button className="cs:h-11" type="submit" form={formId}>
         {children}
       </Button>
     </div>

--- a/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
+++ b/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
@@ -46,10 +46,10 @@ const CreateForm = () => {
       }
     };
 
-    const validate = formValidation(data);
-    setErrors(validate);
+    const errors = formValidation(data);
+    setErrors(errors);
 
-    if (!Object.keys(validate).length) {
+    if (!Object.keys(errors).length) {
       await fetch(apiUrl("/missions/create"), {
         method: "POST",
         body: JSON.stringify(data)

--- a/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
+++ b/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
@@ -4,7 +4,6 @@ import { FormEvent, useRef, useState } from "react";
 
 import Category from "@/components/common/Category";
 import Container from "@/components/common/Container";
-import FooterButton from "@/components/common/FooterButton";
 import useForm, { FormErrors } from "@/hooks/useForm";
 import { apiUrl } from "@/services/urls";
 
@@ -59,7 +58,10 @@ const CreateForm = () => {
   };
 
   return (
-    <form className="flex w-full flex-col items-center" onSubmit={handleSubmit}>
+    <form
+      className="flex w-full flex-col items-center"
+      onSubmit={handleSubmit}
+      id="missionCreateForm">
       <Container className="flex w-full flex-col gap-3 p-5">
         <span className="text-base font-semibold">
           찾는 카테고리가 있으신가요?
@@ -131,7 +133,6 @@ const CreateForm = () => {
           )}
         </div>
       </Container>
-      <FooterButton>생성하기</FooterButton>
     </form>
   );
 };

--- a/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
+++ b/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
@@ -4,14 +4,14 @@ import { FormEvent, useRef, useState } from "react";
 
 import Category from "@/components/common/Category";
 import Container from "@/components/common/Container";
-import useForm, { FormErrors } from "@/hooks/useForm";
+import useFormValidation, { FormErrors } from "@/hooks/useFormValidation";
 import { apiUrl } from "@/services/urls";
 
 import CustomCalendar from "./CustomCalendar";
-import ErrorMessage from "./ErrorMessage";
 import Input from "./Input";
 import InputLabel from "./InputLabel";
 import Select from "./Select";
+import Textarea from "./Textarea";
 
 const hours = Array.from({ length: 24 }, (_, index) => index);
 
@@ -24,7 +24,7 @@ const CreateForm = () => {
   const endRef = useRef<HTMLSelectElement | null>(null);
   const priceRef = useRef<HTMLInputElement | null>(null);
   const contentRef = useRef<HTMLTextAreaElement | null>(null);
-  const { formValidation } = useForm();
+  const { formValidation } = useFormValidation();
 
   const handleSelect = (idx: number) => {
     if (idx > 0) {
@@ -34,7 +34,7 @@ const CreateForm = () => {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-
+    console.log("눌렀다.");
     const data = {
       categoryId,
       missionInfo: {
@@ -46,10 +46,10 @@ const CreateForm = () => {
       }
     };
 
-    const errors = formValidation(data);
-    setErrors(errors);
+    const validationErrors = formValidation(data);
+    setErrors(validationErrors);
 
-    if (!Object.keys(errors).length) {
+    if (!Object.keys(validationErrors).length) {
       await fetch(apiUrl("/missions/create"), {
         method: "POST",
         body: JSON.stringify(data)
@@ -75,8 +75,8 @@ const CreateForm = () => {
           </span>
           <InputLabel htmlFor="title">제목</InputLabel>
           <Input
-            ref={titleRef}
             id="title"
+            ref={titleRef}
             placeholder="미션 제목을 입력하세요."
           />
         </div>
@@ -113,24 +113,19 @@ const CreateForm = () => {
         <div className="flex flex-col">
           <InputLabel htmlFor="price">포상금</InputLabel>
           <Input
-            ref={priceRef}
             id="price"
+            ref={priceRef}
             className="w-6/12"
             error={errors?.missionInfo?.price}
           />
         </div>
         <div className="flex flex-col">
           <InputLabel htmlFor="content">미션 내용</InputLabel>
-          <textarea
-            ref={contentRef}
+          <Textarea
             id="content"
-            className={`border-inactive focus:outline-primary h-[118px] resize-none rounded-[10px] border p-3 text-sm ${
-              errors?.missionInfo?.content && "border-2 border-red-500"
-            }`}
+            ref={contentRef}
+            error={errors?.missionInfo?.content}
           />
-          {errors?.missionInfo?.content && (
-            <ErrorMessage>{errors.missionInfo.content}</ErrorMessage>
-          )}
         </div>
       </Container>
     </form>

--- a/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
+++ b/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { FormEvent, useRef, useState } from "react";
+
+import Category from "@/components/common/Category";
+import Container from "@/components/common/Container";
+import FooterButton from "@/components/common/FooterButton";
+import useForm, { FormErrors } from "@/hooks/useForm";
+import { apiUrl } from "@/services/urls";
+
+import CustomCalendar from "./CustomCalendar";
+import ErrorMessage from "./ErrorMessage";
+import Input from "./Input";
+import InputLabel from "./InputLabel";
+import Select from "./Select";
+
+const hours = Array.from({ length: 24 }, (_, index) => index);
+
+const CreateForm = () => {
+  const [categoryId, setCategoryId] = useState<number>(0);
+  const [errors, setErrors] = useState<FormErrors | null>(null);
+  const titleRef = useRef<HTMLInputElement | null>(null);
+  const dateRef = useRef<HTMLInputElement | null>(null);
+  const startRef = useRef<HTMLSelectElement | null>(null);
+  const endRef = useRef<HTMLSelectElement | null>(null);
+  const priceRef = useRef<HTMLInputElement | null>(null);
+  const contentRef = useRef<HTMLTextAreaElement | null>(null);
+  const { formValidation } = useForm();
+
+  const handleSelect = (idx: number) => {
+    if (idx > 0) {
+      setCategoryId(idx);
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    const data = {
+      categoryId,
+      missionInfo: {
+        content: contentRef.current?.value ?? "",
+        missionDate: dateRef.current?.value ?? "",
+        startTime: startRef.current?.value ?? "",
+        endTime: endRef.current?.value ?? "",
+        price: priceRef.current?.value ?? ""
+      }
+    };
+
+    const validate = formValidation(data);
+    setErrors(validate);
+
+    if (!Object.keys(validate).length) {
+      await fetch(apiUrl("/missions/create"), {
+        method: "POST",
+        body: JSON.stringify(data)
+      });
+    }
+  };
+
+  return (
+    <form className="flex w-full flex-col items-center" onSubmit={handleSubmit}>
+      <Container className="flex w-full flex-col gap-3 p-5">
+        <span className="text-base font-semibold">
+          찾는 카테고리가 있으신가요?
+        </span>
+        <Category onSelect={handleSelect} error={errors?.categoryId} />
+      </Container>
+      <Container className="flex w-full flex-col gap-5 p-5">
+        <div className="flex flex-col">
+          <span className="mb-4 text-base font-semibold">
+            미션에 대한 정보를 알려주세요!
+          </span>
+          <InputLabel htmlFor="title">제목</InputLabel>
+          <Input
+            ref={titleRef}
+            id="title"
+            placeholder="미션 제목을 입력하세요."
+          />
+        </div>
+        <div className="flex flex-col">
+          <InputLabel htmlFor="missionDate">날짜</InputLabel>
+          <CustomCalendar
+            id="missionDate"
+            ref={dateRef}
+            error={errors?.missionInfo?.missionDate}
+          />
+        </div>
+        <div>
+          <InputLabel htmlFor="startTime">시간</InputLabel>
+          <div className="mt-1 flex gap-4">
+            <Select
+              id="startTime"
+              ref={startRef}
+              error={errors?.missionInfo?.startTime}>
+              {hours.map((hour) => (
+                <option key={hour}>{hour}:00</option>
+              ))}
+            </Select>
+            <span>~</span>
+            <Select
+              id="endTime"
+              ref={endRef}
+              error={errors?.missionInfo?.endTime}>
+              {hours.map((hour) => (
+                <option key={hour}>{hour}:00</option>
+              ))}
+            </Select>
+          </div>
+        </div>
+        <div className="flex flex-col">
+          <InputLabel htmlFor="price">포상금</InputLabel>
+          <Input
+            ref={priceRef}
+            id="price"
+            className="w-6/12"
+            error={errors?.missionInfo?.price}
+          />
+        </div>
+        <div className="flex flex-col">
+          <InputLabel htmlFor="content">미션 내용</InputLabel>
+          <textarea
+            ref={contentRef}
+            id="content"
+            className={`border-inactive focus:outline-primary h-[118px] resize-none rounded-[10px] border p-3 text-sm ${
+              errors?.missionInfo?.content && "border-2 border-red-500"
+            }`}
+          />
+          {errors?.missionInfo?.content && (
+            <ErrorMessage>{errors.missionInfo.content}</ErrorMessage>
+          )}
+        </div>
+      </Container>
+      <FooterButton>생성하기</FooterButton>
+    </form>
+  );
+};
+
+export default CreateForm;

--- a/one-day-hero/src/components/domain/mission/create/CustomCalendar.tsx
+++ b/one-day-hero/src/components/domain/mission/create/CustomCalendar.tsx
@@ -64,7 +64,7 @@ const CustomCalendar = forwardRef(
         <Input
           ref={ref}
           id={id}
-          value={inputValue}
+          readOnlyValue={inputValue}
           error={error}
           readOnly
           className={`${error && "border-2 border-red-500"}`}

--- a/one-day-hero/src/components/domain/mission/create/CustomCalendar.tsx
+++ b/one-day-hero/src/components/domain/mission/create/CustomCalendar.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import "react-calendar/dist/Calendar.css";
+
+import { ForwardedRef, forwardRef, useEffect, useRef, useState } from "react";
+import Calendar from "react-calendar";
+import { BiCalendar } from "react-icons/bi";
+
+import Input from "./Input";
+
+type ValuePiece = Date | null;
+type Value = ValuePiece | [ValuePiece, ValuePiece];
+
+type CustomCalendarProps = {
+  id: string;
+  error?: string;
+};
+
+const CustomCalendar = forwardRef(
+  ({ id, error }: CustomCalendarProps, ref: ForwardedRef<HTMLInputElement>) => {
+    const [value, onChange] = useState<Value>(new Date());
+    const [inputValue, setInputValue] = useState<string>("");
+    const [openState, setOpenState] = useState<boolean>(false);
+    const calendarRef = useRef<HTMLDivElement | null>(null);
+
+    const handleChangeDate = (selectedDate: Value) => {
+      onChange(selectedDate);
+      const formatDate = new Date(selectedDate as Date).toLocaleDateString(
+        "ko-KR",
+        {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+          weekday: "long"
+        }
+      );
+      setInputValue(formatDate);
+      setOpenState(false);
+    };
+
+    useEffect(() => {
+      const handleOutsideClick = (event: MouseEvent) => {
+        if (
+          calendarRef.current &&
+          !calendarRef.current.contains(event.target as Node)
+        ) {
+          setOpenState(false);
+        }
+      };
+
+      if (openState) {
+        document.addEventListener("mousedown", handleOutsideClick);
+      } else {
+        document.removeEventListener("mousedown", handleOutsideClick);
+      }
+
+      return () => {
+        document.removeEventListener("mousedown", handleOutsideClick);
+      };
+    }, [openState]);
+
+    return (
+      <div className="relative flex w-full">
+        <Input
+          ref={ref}
+          id={id}
+          value={inputValue}
+          error={error}
+          readOnly
+          className={`${error && "border-2 border-red-500"}`}
+        />
+        {openState ? (
+          <div ref={calendarRef}>
+            <Calendar
+              onChange={handleChangeDate}
+              className="absolute right-0 top-0"
+              value={value}
+              formatDay={(_, date) =>
+                new Date(date).toLocaleDateString("en-us", { day: "2-digit" })
+              }
+            />
+          </div>
+        ) : (
+          <div className="w-3/12">
+            <BiCalendar
+              className="ml-2 text-3xl"
+              onClick={() => setOpenState(true)}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+CustomCalendar.displayName = "CustomCalendar";
+
+export default CustomCalendar;

--- a/one-day-hero/src/components/domain/mission/create/ErrorMessage.tsx
+++ b/one-day-hero/src/components/domain/mission/create/ErrorMessage.tsx
@@ -1,0 +1,9 @@
+import { PropsWithChildren } from "react";
+
+const ErrorMessage = ({ children }: PropsWithChildren) => {
+  const defaultStyle = "text-red-500 text-sm mt-1";
+
+  return <span className={`${defaultStyle}`}>{children}</span>;
+};
+
+export default ErrorMessage;

--- a/one-day-hero/src/components/domain/mission/create/Input.tsx
+++ b/one-day-hero/src/components/domain/mission/create/Input.tsx
@@ -1,20 +1,30 @@
 "use client";
 
-import { ForwardedRef, forwardRef, useState } from "react";
+import { ForwardedRef, forwardRef } from "react";
+
+import useForm from "@/hooks/useForm";
 
 import ErrorMessage from "./ErrorMessage";
 
 interface InputProps extends React.ComponentProps<"input"> {
+  readOnlyValue?: string;
   className?: string;
   error?: string;
 }
 
 const Input = forwardRef(
   (
-    { id, className, value, placeholder = "", readOnly, error }: InputProps,
+    {
+      id,
+      className,
+      readOnlyValue,
+      placeholder = "",
+      readOnly,
+      error
+    }: InputProps,
     ref: ForwardedRef<HTMLInputElement>
   ) => {
-    const [inputValue, setInputValue] = useState<string>("");
+    const { value, handleChange, errorState } = useForm("", error || "");
 
     const defaultStyle =
       "rounded-[10px] h-[34px] w-full border border-zinc-300 focus:outline-primary placeholder:text-inactive pl-3";
@@ -22,17 +32,17 @@ const Input = forwardRef(
     return (
       <div className="flex grow flex-col">
         <input
-          ref={ref}
           id={id}
-          value={readOnly ? value?.toString() : inputValue}
+          ref={ref}
+          value={readOnly ? readOnlyValue?.toString() : value}
           placeholder={placeholder}
-          className={`${defaultStyle} ${className} ${
-            error && "cs:border-red-500 border-2"
-          }`}
-          onChange={(e) => !readOnly && setInputValue(e.target.value)}
+          onChange={!readOnly ? handleChange : undefined}
           readOnly={readOnly}
+          className={`${defaultStyle} ${className} ${
+            error && errorState && "cs:border-red-500 border-2"
+          }`}
         />
-        {error && <ErrorMessage>{error}</ErrorMessage>}
+        {error && errorState && <ErrorMessage>{error}</ErrorMessage>}
       </div>
     );
   }

--- a/one-day-hero/src/components/domain/mission/create/Input.tsx
+++ b/one-day-hero/src/components/domain/mission/create/Input.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { ForwardedRef, forwardRef, useState } from "react";
+
+import ErrorMessage from "./ErrorMessage";
+
+interface InputProps extends React.ComponentProps<"input"> {
+  className?: string;
+  error?: string;
+}
+
+const Input = forwardRef(
+  (
+    { id, className, value, placeholder = "", readOnly, error }: InputProps,
+    ref: ForwardedRef<HTMLInputElement>
+  ) => {
+    const [inputValue, setInputValue] = useState<string>("");
+
+    const defaultStyle =
+      "rounded-[10px] h-[34px] w-full border border-zinc-300 focus:outline-primary placeholder:text-inactive pl-3";
+
+    return (
+      <div className="flex grow flex-col">
+        <input
+          ref={ref}
+          id={id}
+          value={readOnly ? value?.toString() : inputValue}
+          placeholder={placeholder}
+          className={`${defaultStyle} ${className} ${
+            error && "cs:border-red-500 border-2"
+          }`}
+          onChange={(e) => !readOnly && setInputValue(e.target.value)}
+          readOnly={readOnly}
+        />
+        {error && <ErrorMessage>{error}</ErrorMessage>}
+      </div>
+    );
+  }
+);
+
+Input.displayName = "Input";
+
+export default Input;

--- a/one-day-hero/src/components/domain/mission/create/InputLabel.tsx
+++ b/one-day-hero/src/components/domain/mission/create/InputLabel.tsx
@@ -1,0 +1,21 @@
+import { PropsWithChildren } from "react";
+
+interface InputLabelProps extends React.ComponentProps<"label"> {
+  className?: string;
+}
+
+const InputLabel = ({
+  htmlFor,
+  className,
+  children
+}: PropsWithChildren<InputLabelProps>) => {
+  const defaultStyle = "mb-1 text-sm font-semibold w-fit";
+
+  return (
+    <label htmlFor={htmlFor} className={`${defaultStyle} ${className}`}>
+      {children}
+    </label>
+  );
+};
+
+export default InputLabel;

--- a/one-day-hero/src/components/domain/mission/create/Select.tsx
+++ b/one-day-hero/src/components/domain/mission/create/Select.tsx
@@ -2,6 +2,8 @@
 
 import { ForwardedRef, forwardRef, PropsWithChildren } from "react";
 
+import useForm from "@/hooks/useForm";
+
 import ErrorMessage from "./ErrorMessage";
 
 interface SelectProps extends React.ComponentProps<"select"> {
@@ -14,20 +16,23 @@ const Select = forwardRef(
     { id, className, children, error }: PropsWithChildren<SelectProps>,
     ref: ForwardedRef<HTMLSelectElement>
   ) => {
+    const { handleChange, errorState } = useForm("", error || "");
+
     const defaultStyle =
       "border-bg-inactive focus:outline-primary w-full h-[34px] rounded-[10px] border pl-2";
 
     return (
       <div className="flex w-full flex-col">
         <select
-          ref={ref}
           id={id}
+          ref={ref}
+          onChange={handleChange}
           className={`${defaultStyle} ${className} ${
-            error && "border-2 border-red-500"
+            error && errorState && "border-2 border-red-500"
           }`}>
           {children}
         </select>
-        {error && <ErrorMessage>{error}</ErrorMessage>}
+        {error && errorState && <ErrorMessage>{error}</ErrorMessage>}
       </div>
     );
   }

--- a/one-day-hero/src/components/domain/mission/create/Select.tsx
+++ b/one-day-hero/src/components/domain/mission/create/Select.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { ForwardedRef, forwardRef, PropsWithChildren } from "react";
+
+import ErrorMessage from "./ErrorMessage";
+
+interface SelectProps extends React.ComponentProps<"select"> {
+  className?: string;
+  error?: string;
+}
+
+const Select = forwardRef(
+  (
+    { id, className, children, error }: PropsWithChildren<SelectProps>,
+    ref: ForwardedRef<HTMLSelectElement>
+  ) => {
+    const defaultStyle =
+      "border-bg-inactive focus:outline-primary w-full h-[34px] rounded-[10px] border pl-2";
+
+    return (
+      <div className="flex w-full flex-col">
+        <select
+          ref={ref}
+          id={id}
+          className={`${defaultStyle} ${className} ${
+            error && "border-2 border-red-500"
+          }`}>
+          {children}
+        </select>
+        {error && <ErrorMessage>{error}</ErrorMessage>}
+      </div>
+    );
+  }
+);
+
+Select.displayName = "Select";
+
+export default Select;

--- a/one-day-hero/src/components/domain/mission/create/Textarea.tsx
+++ b/one-day-hero/src/components/domain/mission/create/Textarea.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { ForwardedRef, forwardRef } from "react";
+
+import useForm from "@/hooks/useForm";
+
+import ErrorMessage from "./ErrorMessage";
+
+interface TextareaProps extends React.ComponentProps<"textarea"> {
+  className?: string;
+  error?: string;
+}
+
+const Textarea = forwardRef(
+  (
+    { id, className, error }: TextareaProps,
+    ref: ForwardedRef<HTMLTextAreaElement>
+  ) => {
+    const { value, handleChange, errorState } = useForm("", error || "");
+
+    const defaultStyle =
+      "border-inactive focus:outline-primary h-[118px] resize-none rounded-[10px] placeholder:text-inactive border p-3 text-sm";
+
+    return (
+      <>
+        <textarea
+          id={id}
+          ref={ref}
+          value={value}
+          placeholder="미션에 대한 내용을 작성해주세요!"
+          onChange={handleChange}
+          className={`${defaultStyle} ${className} ${
+            error && errorState && "border-2 border-red-500"
+          }`}
+        />
+        {error && errorState && <ErrorMessage>{error}</ErrorMessage>}
+      </>
+    );
+  }
+);
+
+Textarea.displayName = "Textarea";
+
+export default Textarea;

--- a/one-day-hero/src/constants/errorMessage.ts
+++ b/one-day-hero/src/constants/errorMessage.ts
@@ -1,0 +1,8 @@
+export const FORM_ERROR_MESSAGES = {
+  CHECK_EMPTY_CATEGORY: "카테고리를 선택해주세요.",
+  CHECK_EMPTY_TITLE: "타이틀을 입력하세요.",
+  CHECK_EMPTY_DATE: "미션 날짜를 선택해주세요.",
+  CHECK_SAME_TIME: "미션 타임을 다시 선택해주세요.",
+  CHECK_EMPTY_PRICE: "포상금을 입력해주세요.",
+  CHECK_EMPTY_CONTENT: "미션 내용을 작성해주세요."
+};

--- a/one-day-hero/src/hooks/useForm.ts
+++ b/one-day-hero/src/hooks/useForm.ts
@@ -30,7 +30,7 @@ const useForm = () => {
       errors.categoryId = FORM_ERROR_MESSAGES.CHECK_EMPTY_CATEGORY;
     }
 
-    if (!missionDate || missionDate.length === 0) {
+    if (!missionDate || missionDate.length <= 0) {
       errors.missionInfo = {
         ...errors.missionInfo,
         missionDate: FORM_ERROR_MESSAGES.CHECK_EMPTY_DATE
@@ -45,14 +45,14 @@ const useForm = () => {
       };
     }
 
-    if (!price || price.trim().length === 0) {
+    if (!price || price.trim().length <= 0 || !Number(price)) {
       errors.missionInfo = {
         ...errors.missionInfo,
         price: FORM_ERROR_MESSAGES.CHECK_EMPTY_PRICE
       };
     }
 
-    if (!content || content.trim().length === 0) {
+    if (!content || content.trim().length <= 0) {
       errors.missionInfo = {
         ...errors.missionInfo,
         content: FORM_ERROR_MESSAGES.CHECK_EMPTY_CONTENT

--- a/one-day-hero/src/hooks/useForm.ts
+++ b/one-day-hero/src/hooks/useForm.ts
@@ -1,68 +1,19 @@
-import { FORM_ERROR_MESSAGES } from "@/constants/errorMessage";
+import { ChangeEvent, useEffect, useState } from "react";
+const useForm = (initialValue: string, error: string) => {
+  const [value, setValue] = useState<string>(initialValue);
+  const [errorState, setErrorState] = useState<boolean>(false);
 
-export type MissionInfoProps = {
-  content: string;
-  missionDate: string;
-  startTime: string;
-  endTime: string;
-  price: string;
-};
-
-export type FormErrors = {
-  categoryId?: string;
-  missionInfo?: Partial<MissionInfoProps>;
-};
-
-export type FormRequest = {
-  categoryId: number;
-  missionInfo: MissionInfoProps;
-};
-
-const useForm = () => {
-  const formValidation = (data: FormRequest) => {
-    const errors: FormErrors = {};
-    const {
-      categoryId,
-      missionInfo: { missionDate, startTime, endTime, price, content }
-    } = data;
-
-    if (!categoryId) {
-      errors.categoryId = FORM_ERROR_MESSAGES.CHECK_EMPTY_CATEGORY;
-    }
-
-    if (!missionDate || missionDate.length <= 0) {
-      errors.missionInfo = {
-        ...errors.missionInfo,
-        missionDate: FORM_ERROR_MESSAGES.CHECK_EMPTY_DATE
-      };
-    }
-
-    if (!startTime || !endTime || startTime === endTime) {
-      errors.missionInfo = {
-        ...errors.missionInfo,
-        startTime: FORM_ERROR_MESSAGES.CHECK_SAME_TIME,
-        endTime: FORM_ERROR_MESSAGES.CHECK_SAME_TIME
-      };
-    }
-
-    if (!price || price.trim().length <= 0 || !Number(price)) {
-      errors.missionInfo = {
-        ...errors.missionInfo,
-        price: FORM_ERROR_MESSAGES.CHECK_EMPTY_PRICE
-      };
-    }
-
-    if (!content || content.trim().length <= 0) {
-      errors.missionInfo = {
-        ...errors.missionInfo,
-        content: FORM_ERROR_MESSAGES.CHECK_EMPTY_CONTENT
-      };
-    }
-
-    return errors;
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
+  ) => {
+    setValue(e.target.value);
+    errorState && setErrorState(false);
   };
 
-  return { formValidation };
-};
+  useEffect(() => {
+    error && setErrorState(true);
+  }, [error, errorState]);
 
+  return { value, errorState, handleChange };
+};
 export default useForm;

--- a/one-day-hero/src/hooks/useForm.ts
+++ b/one-day-hero/src/hooks/useForm.ts
@@ -1,0 +1,68 @@
+import { FORM_ERROR_MESSAGES } from "@/constants/errorMessage";
+
+export type MissionInfoProps = {
+  content: string;
+  missionDate: string;
+  startTime: string;
+  endTime: string;
+  price: string;
+};
+
+export type FormErrors = {
+  categoryId?: string;
+  missionInfo?: Partial<MissionInfoProps>;
+};
+
+export type FormRequest = {
+  categoryId: number;
+  missionInfo: MissionInfoProps;
+};
+
+const useForm = () => {
+  const formValidation = (data: FormRequest) => {
+    const errors: FormErrors = {};
+    const {
+      categoryId,
+      missionInfo: { missionDate, startTime, endTime, price, content }
+    } = data;
+
+    if (!categoryId) {
+      errors.categoryId = FORM_ERROR_MESSAGES.CHECK_EMPTY_CATEGORY;
+    }
+
+    if (!missionDate || missionDate.length === 0) {
+      errors.missionInfo = {
+        ...errors.missionInfo,
+        missionDate: FORM_ERROR_MESSAGES.CHECK_EMPTY_DATE
+      };
+    }
+
+    if (!startTime || !endTime || startTime === endTime) {
+      errors.missionInfo = {
+        ...errors.missionInfo,
+        startTime: FORM_ERROR_MESSAGES.CHECK_SAME_TIME,
+        endTime: FORM_ERROR_MESSAGES.CHECK_SAME_TIME
+      };
+    }
+
+    if (!price || price.trim().length === 0) {
+      errors.missionInfo = {
+        ...errors.missionInfo,
+        price: FORM_ERROR_MESSAGES.CHECK_EMPTY_PRICE
+      };
+    }
+
+    if (!content || content.trim().length === 0) {
+      errors.missionInfo = {
+        ...errors.missionInfo,
+        content: FORM_ERROR_MESSAGES.CHECK_EMPTY_CONTENT
+      };
+    }
+
+    return errors;
+  };
+
+  return { formValidation };
+};
+
+export default useForm;

--- a/one-day-hero/src/hooks/useFormValidation.ts
+++ b/one-day-hero/src/hooks/useFormValidation.ts
@@ -1,0 +1,68 @@
+import { FORM_ERROR_MESSAGES } from "@/constants/errorMessage";
+
+export type MissionInfoProps = {
+  content: string;
+  missionDate: string;
+  startTime: string;
+  endTime: string;
+  price: string;
+};
+
+export type FormErrors = {
+  categoryId?: string;
+  missionInfo?: Partial<MissionInfoProps>;
+};
+
+export type FormRequest = {
+  categoryId: number;
+  missionInfo: MissionInfoProps;
+};
+
+const useFormValidation = () => {
+  const formValidation = (data: FormRequest) => {
+    const errors: FormErrors = {};
+    const {
+      categoryId,
+      missionInfo: { missionDate, startTime, endTime, price, content }
+    } = data;
+
+    if (!categoryId) {
+      errors.categoryId = FORM_ERROR_MESSAGES.CHECK_EMPTY_CATEGORY;
+    }
+
+    if (!missionDate || missionDate.length <= 0) {
+      errors.missionInfo = {
+        ...errors.missionInfo,
+        missionDate: FORM_ERROR_MESSAGES.CHECK_EMPTY_DATE
+      };
+    }
+
+    if (!startTime || !endTime || startTime === endTime) {
+      errors.missionInfo = {
+        ...errors.missionInfo,
+        startTime: FORM_ERROR_MESSAGES.CHECK_SAME_TIME,
+        endTime: FORM_ERROR_MESSAGES.CHECK_SAME_TIME
+      };
+    }
+
+    if (!price || price.trim().length <= 0 || isNaN(Number(price))) {
+      errors.missionInfo = {
+        ...errors.missionInfo,
+        price: FORM_ERROR_MESSAGES.CHECK_EMPTY_PRICE
+      };
+    }
+
+    if (!content || content.trim().length <= 0) {
+      errors.missionInfo = {
+        ...errors.missionInfo,
+        content: FORM_ERROR_MESSAGES.CHECK_EMPTY_CONTENT
+      };
+    }
+
+    return errors;
+  };
+
+  return { formValidation };
+};
+
+export default useFormValidation;


### PR DESCRIPTION
## 구현 내용
- 미션 생성 페이지를 구현합니다.
- 제가 생각하는 방식에서 react-hook-form 과 비슷하게 ref로 각 input 값들을 관리하였습니다.
- 기본적인 유효성 검사는 추가했으나 실시간으로 입력이 없다가 생기면 바로 에러메세지가 사라지는 등의 동작은 아직 못했습니다..
  - 이미지를 업로드하는 컴포넌트도 이 폼에 추가해야되서 머지가 되면 input에 change 이벤트가 발생한다면 error message를 사라지게 한다는 등으로 구현해보겠습니다.  
## 스크린샷

https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/117630589/4bcb8b5c-3189-41fc-8946-285543ac292a

## 궁금한 점
- 이렇게 ref로 관리하는 방식이 적절할 지 모르겠습니다..
## 이슈번호
- closes #55 
