### PR TITLE
Data Fetching 함수 에러 처리 추상화

### DIFF
--- a/one-day-hero/src/app/citizenProfile/[slug]/page.tsx
+++ b/one-day-hero/src/app/citizenProfile/[slug]/page.tsx
@@ -2,14 +2,19 @@ import Image from "next/image";
 import { BiChevronRight } from "react-icons/bi";
 
 import DefaultThumbnail from "/public/images/OneDayHero_logo_sm.svg";
+import ErrorPage from "@/app/error";
 import Button from "@/components/common/Button";
 import HeroScore from "@/components/common/HeroScore";
-import { getUser } from "@/services/users";
+import { useGetUserFetch } from "@/services/users";
 
 const CitizenProfilePage = async ({ params }: { params: { slug: string } }) => {
+  const { isError, response } = await useGetUserFetch(parseInt(params.slug));
+
+  if (isError || !response) return <ErrorPage />;
+
   const {
     data: { basicInfo }
-  } = await getUser(parseInt(params.slug));
+  } = response;
 
   return (
     <>

--- a/one-day-hero/src/app/error.tsx
+++ b/one-day-hero/src/app/error.tsx
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
 
-export default function Error({
+export default function ErrorPage({
   error,
   reset
 }: {

--- a/one-day-hero/src/app/error.tsx
+++ b/one-day-hero/src/app/error.tsx
@@ -1,8 +1,9 @@
 "use client"; // Error components must be Client Components
 
-import { revalidatePath } from "next/cache";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+
+import Button from "@/components/common/Button";
 
 export default function ErrorPage({
   error,
@@ -12,7 +13,6 @@ export default function ErrorPage({
   reset?: () => void;
 }) {
   const router = useRouter();
-  const pathname = usePathname();
 
   useEffect(() => {
     console.error(error);
@@ -21,15 +21,14 @@ export default function ErrorPage({
   const handleReset = () => {
     if (reset) reset();
     else {
-      revalidatePath(pathname);
       router.refresh();
     }
   };
 
   return (
-    <div className="flex h-full w-full items-center justify-center">
+    <div className="flex h-full w-full flex-col items-center justify-center">
       <h2>Something went wrong!</h2>
-      <button onClick={handleReset}>Try again</button>
+      <Button onClick={handleReset}>Try again</Button>
     </div>
   );
 }

--- a/one-day-hero/src/app/error.tsx
+++ b/one-day-hero/src/app/error.tsx
@@ -1,0 +1,35 @@
+"use client"; // Error components must be Client Components
+
+import { revalidatePath } from "next/cache";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset
+}: {
+  error?: Error & { digest?: string };
+  reset?: () => void;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const handleReset = () => {
+    if (reset) reset();
+    else {
+      revalidatePath(pathname);
+      router.refresh();
+    }
+  };
+
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <h2>Something went wrong!</h2>
+      <button onClick={handleReset}>Try again</button>
+    </div>
+  );
+}

--- a/one-day-hero/src/app/error.tsx
+++ b/one-day-hero/src/app/error.tsx
@@ -1,4 +1,4 @@
-"use client"; // Error components must be Client Components
+"use client";
 
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";

--- a/one-day-hero/src/app/heroProfile/[slug]/page.tsx
+++ b/one-day-hero/src/app/heroProfile/[slug]/page.tsx
@@ -2,16 +2,21 @@ import Image from "next/image";
 import { BiChevronRight } from "react-icons/bi";
 
 import DefaultThumbnail from "/public/images/OneDayHero_logo_sm.svg";
+import ErrorPage from "@/app/error";
 import Button from "@/components/common/Button";
 import FavoriteDateList from "@/components/common/FavoriteDateList";
 import HeroScore from "@/components/common/HeroScore";
 import Label from "@/components/common/Label";
-import { getUser } from "@/services/users";
+import { useGetUserFetch } from "@/services/users";
 
 const HeroProfilePage = async ({ params }: { params: { slug: string } }) => {
+  const { isError, response } = await useGetUserFetch(parseInt(params.slug));
+
+  if (isError || !response) return <ErrorPage />;
+
   const {
     data: { basicInfo, favoriteWorkingDay }
-  } = await getUser(parseInt(params.slug));
+  } = response;
 
   return (
     <>

--- a/one-day-hero/src/app/mission/[slug]/page.tsx
+++ b/one-day-hero/src/app/mission/[slug]/page.tsx
@@ -1,6 +1,6 @@
-import { revalidateTag } from "next/cache";
 import { BiChevronRight, BiEdit, BiMap } from "react-icons/bi";
 
+import ErrorPage from "@/app/error";
 import BookmarkButton from "@/components/common/BookmarkButton";
 import Button from "@/components/common/Button";
 import Container from "@/components/common/Container";
@@ -9,12 +9,16 @@ import MissionInfo from "@/components/common/Info/MissionInfo";
 import Label from "@/components/common/Label";
 import CitizenInfo from "@/components/domain/missionDetail/CitizenInfo";
 import HeroRecommendList from "@/components/domain/missionDetail/HeroRecommendList";
-import { getMission } from "@/services/missions";
+import { useGetMissionFetch } from "@/services/missions";
 
 const MissionDetailPage = async ({ params }: { params: { slug: string } }) => {
+  /**@note useSession 사용 예정 */
   const userId = parseInt(params.slug);
 
-  revalidateTag(`mission${params.slug}`);
+  const { isError, response } = await useGetMissionFetch("1");
+
+  if (isError || !response) return <ErrorPage />;
+
   const {
     data: {
       id,
@@ -25,7 +29,7 @@ const MissionDetailPage = async ({ params }: { params: { slug: string } }) => {
       bookmarkCount,
       isBookmarked
     }
-  } = await getMission("1");
+  } = response;
 
   const isOwner = userId === citizenId;
 

--- a/one-day-hero/src/app/mission/list/ongoing/page.tsx
+++ b/one-day-hero/src/app/mission/list/ongoing/page.tsx
@@ -1,12 +1,17 @@
 import Link from "next/link";
 
+import ErrorPage from "@/app/error";
 import MissionListItem from "@/components/common/Info/MissionListItem";
 import MissionProgressContainer from "@/components/common/MissionProgressContainer";
-import { getOngoingMissionList } from "@/services/missions";
+import { useGetOngoingMissionListFetch } from "@/services/missions";
 import { MissionResponse } from "@/types/response";
 
 const OngoingMissionPage = async () => {
-  const { data } = await getOngoingMissionList();
+  const { isError, response } = await useGetOngoingMissionListFetch();
+
+  if (isError || !response) return <ErrorPage />;
+
+  const { data } = response;
 
   return (
     <div className="mt-20 w-full max-w-screen-sm space-y-4">

--- a/one-day-hero/src/app/mission/list/suggested/page.tsx
+++ b/one-day-hero/src/app/mission/list/suggested/page.tsx
@@ -1,13 +1,18 @@
 import Link from "next/link";
 
+import ErrorPage from "@/app/error";
 import Button from "@/components/common/Button";
 import Container from "@/components/common/Container";
 import MissionFullInfo from "@/components/common/Info/MissionFullInfo";
-import { getSuggestedMissionList } from "@/services/missions";
+import { useGetSuggestedMissionListFetch } from "@/services/missions";
 import { MissionResponse } from "@/types/response";
 
 const SuggestedMissionPage = async () => {
-  const { data } = await getSuggestedMissionList();
+  const { isError, response } = await useGetSuggestedMissionListFetch();
+
+  if (isError || !response) return <ErrorPage />;
+
+  const { data } = response;
 
   return (
     <div className="mt-20 flex w-full max-w-screen-sm flex-col items-center justify-center space-y-4">

--- a/one-day-hero/src/app/mission/record/page.tsx
+++ b/one-day-hero/src/app/mission/record/page.tsx
@@ -1,10 +1,15 @@
+import ErrorPage from "@/app/error";
 import Container from "@/components/common/Container";
 import MissionListItem from "@/components/common/Info/MissionListItem";
 import MissionProgressBar from "@/components/common/MissionProgressBar";
-import { getCompletedMission } from "@/services/missions";
+import { useGetCompletedMissionFetch } from "@/services/missions";
 
 const MissionRecordPage = async () => {
-  const { data: missions } = await getCompletedMission();
+  const { isError, response } = await useGetCompletedMissionFetch();
+
+  if (isError || !response) return <ErrorPage />;
+
+  const { data: missions } = response;
 
   return (
     <div className="flex w-full flex-col items-center gap-3">

--- a/one-day-hero/src/app/page.tsx
+++ b/one-day-hero/src/app/page.tsx
@@ -1,5 +1,0 @@
-const HomePage = () => {
-  return <div>HomePage</div>;
-};
-
-export default HomePage;

--- a/one-day-hero/src/components/common/BookmarkButton.tsx
+++ b/one-day-hero/src/components/common/BookmarkButton.tsx
@@ -4,7 +4,10 @@ import { useState } from "react";
 import { BiSolidStar } from "react-icons/bi";
 
 import Button from "@/components/common/Button";
-import { deleteBookmark, postBookmark } from "@/services/missions";
+import {
+  useDeleteBookmarkFetch,
+  usePostBookmarkFetch
+} from "@/services/missions";
 
 import IconGroup from "./IconGroup";
 
@@ -30,21 +33,28 @@ const BookmarkButton = ({
     isBookmarked
   });
 
+  const { mutationalFetch: postBookmark } = usePostBookmarkFetch(
+    missionId,
+    userId
+  );
+  const { mutationalFetch: deleteBookmark } = useDeleteBookmarkFetch(
+    missionId,
+    userId
+  );
+
   const handleClick = async () => {
     const currentBookmarkState = optimisticBookmarkState;
+
     setOptimisticBookmarkState({
       bookmarkCount: isBookmarked ? bookmarkCount - 1 : bookmarkCount + 1,
       isBookmarked: !isBookmarked
     });
 
-    try {
-      await (isBookmarked
-        ? deleteBookmark(missionId, userId)
-        : postBookmark(missionId, userId));
-    } catch (err) {
-      console.error(err);
-      setOptimisticBookmarkState(currentBookmarkState);
-    }
+    const { isError } = await (isBookmarked
+      ? deleteBookmark()
+      : postBookmark());
+
+    if (isError) setOptimisticBookmarkState(currentBookmarkState);
   };
 
   const starColor = optimisticBookmarkState.isBookmarked

--- a/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
+++ b/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
@@ -5,7 +5,7 @@ import { FormEvent, useRef, useState } from "react";
 import Category from "@/components/common/Category";
 import Container from "@/components/common/Container";
 import useFormValidation, { FormErrors } from "@/hooks/useFormValidation";
-import { apiUrl } from "@/services/urls";
+import { apiUrl } from "@/services/base";
 
 import CustomCalendar from "./CustomCalendar";
 import Input from "./Input";

--- a/one-day-hero/src/components/domain/missionDetail/CitizenInfo.tsx
+++ b/one-day-hero/src/components/domain/missionDetail/CitizenInfo.tsx
@@ -2,18 +2,23 @@ import Image from "next/image";
 import { BiChevronRight } from "react-icons/bi";
 
 import DefaultThumbnail from "/public/images/OneDayHero_logo_sm.svg";
+import ErrorPage from "@/app/error";
 import Container from "@/components/common/Container";
 import HeroScore from "@/components/common/HeroScore";
-import { getUser } from "@/services/users";
+import { useGetUserFetch } from "@/services/users";
 
 interface CitizenInfoProps extends React.ComponentProps<"div"> {
   citizenId: number;
 }
 
 const CitizenInfo = async ({ citizenId, className }: CitizenInfoProps) => {
+  const { isError, response } = await useGetUserFetch(citizenId);
+
+  if (isError || !response) return <ErrorPage />;
+
   const {
     data: { basicInfo }
-  } = await getUser(citizenId);
+  } = response;
 
   return (
     <Container className={`cs:w-full ${className}`}>

--- a/one-day-hero/src/services/base.ts
+++ b/one-day-hero/src/services/base.ts
@@ -1,0 +1,48 @@
+const makeUrl = (baseUrl: string) => (path: string) => baseUrl + path;
+
+const apiBaseUrl =
+  process.env.NEXT_PUBLIC_API_MOCKING === "enabled"
+    ? `${process.env.NEXT_PUBLIC_FE_URL}/api/v1/mock`
+    : `${process.env.NEXT_PUBLIC_BE_URL}/api/v1`;
+
+export const apiUrl = makeUrl(apiBaseUrl);
+
+type CustomResponse<T> = {
+  isError: boolean;
+  errorMessage?: string;
+  response?: T;
+};
+
+export const useFetch = async <T>(
+  pathname: string,
+  options?: RequestInit,
+  callback?: () => void
+): Promise<CustomResponse<T>> => {
+  try {
+    const response = await fetch(apiUrl(pathname), options);
+
+    const customResponse: CustomResponse<T> = {
+      isError: false,
+      errorMessage: ""
+    };
+
+    if (!response.ok) {
+      customResponse.isError = true;
+      customResponse.errorMessage = response.statusText;
+    }
+
+    const bodyData = (await response.json()) as T;
+    customResponse.response = bodyData;
+
+    callback?.();
+
+    return customResponse;
+  } catch (err) {
+    const errorResponse: CustomResponse<T> = {
+      isError: true,
+      errorMessage: (err as Error)?.message
+    };
+
+    return errorResponse;
+  }
+};

--- a/one-day-hero/src/services/base.ts
+++ b/one-day-hero/src/services/base.ts
@@ -46,3 +46,13 @@ export const useFetch = async <T>(
     return errorResponse;
   }
 };
+
+export const useMutationalFetch = <T>(
+  pathname: string,
+  options: RequestInit,
+  callback?: () => void
+) => {
+  return {
+    mutationalFetch: (useFetch<T>).bind(null, pathname, options, callback)
+  };
+};

--- a/one-day-hero/src/services/missions.ts
+++ b/one-day-hero/src/services/missions.ts
@@ -5,7 +5,7 @@ import {
   SuggestedMissionListResponse
 } from "@/types/response";
 
-import { apiUrl } from "./urls";
+import { apiUrl } from "./base";
 
 export const getTestMissions = async () => {
   const res = await fetch(apiUrl("/missions"));

--- a/one-day-hero/src/services/missions.ts
+++ b/one-day-hero/src/services/missions.ts
@@ -1,87 +1,62 @@
 import { revalidatePath } from "next/cache";
 
 import {
+  BookmarkResponse,
   MissionResponse,
+  OngoingMissionListResponse,
   SuggestedMissionListResponse
 } from "@/types/response";
 
-import { apiUrl } from "./base";
+import { useFetch } from "./base";
 
-export const getTestMissions = async () => {
-  const res = await fetch(apiUrl("/missions"));
-  return res.json();
-};
-
-export const getMission = async (
-  missionId: string
-): Promise<MissionResponse> => {
-  const response = await fetch(apiUrl(`/missions/${missionId}`), {
+export const useGetMissionFetch = (missionId: string) => {
+  return useFetch<MissionResponse>(`/missions/${missionId}`, {
     next: { tags: [`mission${missionId}`] }
   });
-  return response.json();
 };
 
-export const getCompletedMission =
-  async (): Promise<SuggestedMissionListResponse> => {
-    const response = await fetch(apiUrl(`/missions/record`), {
-      next: { tags: ["record"] }
-    });
-
-    return response.json();
-  };
-
-export const postBookmark = async (missionId: number, userId: number) => {
-  const response = await fetch(apiUrl("/bookmarks"), {
-    method: "POST",
-    body: JSON.stringify({
-      missionId,
-      userId
-    })
+export const useGetCompletedMissionFetch = () => {
+  return useFetch<SuggestedMissionListResponse>(`/missions/record`, {
+    next: { tags: ["record"] }
   });
-
-  if (!response.ok) {
-    throw new Error("Failed to fetch data");
-  }
-
-  revalidatePath("/mission/[slug]", "page");
-
-  return response.json();
 };
 
-export const deleteBookmark = async (missionId: number, userId: number) => {
-  const response = await fetch(apiUrl("/bookmarks"), {
-    method: "DELETE",
-    body: JSON.stringify({
-      missionId,
-      userId
-    })
+export const usePostBookmarkFetch = (missionId: number, userId: number) => {
+  return useFetch<BookmarkResponse>(
+    "/bookmarks",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        missionId,
+        userId
+      })
+    },
+    () => revalidatePath("/mission/[slug]", "page")
+  );
+};
+
+export const useDeleteBookmarkFetch = (missionId: number, userId: number) => {
+  return useFetch<BookmarkResponse>(
+    "/bookmarks",
+    {
+      method: "DELETE",
+      body: JSON.stringify({
+        missionId,
+        userId
+      })
+    },
+    () => revalidatePath("/mission/[slug]", "page")
+  );
+};
+
+export const useGetOngoingMissionListFetch = () => {
+  return useFetch<OngoingMissionListResponse>(`/missions/list/ongoing`, {
+    next: { tags: [`ongoing`] }
   });
-
-  revalidatePath("/mission/[slug]", "page");
-
-  return response.json();
 };
 
-export const getOngoingMissionList = async () => {
-  try {
-    const response = await fetch(apiUrl(`/missions/list/ongoing`), {
-      next: { tags: [`ongoing`] }
-    });
-
-    return response.json();
-  } catch (err) {
-    console.error(err);
-  }
-};
-
-export const getSuggestedMissionList = async () => {
-  try {
-    const response = await fetch(apiUrl(`/missions/list/suggested`), {
-      next: { tags: [`suggested`] }
-    });
-
-    return response.json();
-  } catch (err) {
-    console.error(err);
-  }
+export const useGetSuggestedMissionListFetch = () => {
+  return useFetch<SuggestedMissionListResponse>(`/missions/list/suggested`, {
+    next: { tags: [`suggested`] }
+  });
 };

--- a/one-day-hero/src/services/missions.ts
+++ b/one-day-hero/src/services/missions.ts
@@ -7,7 +7,7 @@ import {
   SuggestedMissionListResponse
 } from "@/types/response";
 
-import { useFetch } from "./base";
+import { useFetch, useMutationalFetch } from "./base";
 
 export const useGetMissionFetch = (missionId: string) => {
   return useFetch<MissionResponse>(`/missions/${missionId}`, {
@@ -22,7 +22,7 @@ export const useGetCompletedMissionFetch = () => {
 };
 
 export const usePostBookmarkFetch = (missionId: number, userId: number) => {
-  return useFetch<BookmarkResponse>(
+  return useMutationalFetch<BookmarkResponse>(
     "/bookmarks",
     {
       method: "POST",
@@ -36,7 +36,7 @@ export const usePostBookmarkFetch = (missionId: number, userId: number) => {
 };
 
 export const useDeleteBookmarkFetch = (missionId: number, userId: number) => {
-  return useFetch<BookmarkResponse>(
+  return useMutationalFetch<BookmarkResponse>(
     "/bookmarks",
     {
       method: "DELETE",

--- a/one-day-hero/src/services/urls.ts
+++ b/one-day-hero/src/services/urls.ts
@@ -1,8 +1,0 @@
-const makeUrl = (baseUrl: string) => (path: string) => baseUrl + path;
-
-const apiBaseUrl =
-  process.env.NEXT_PUBLIC_API_MOCKING === "enabled"
-    ? `${process.env.NEXT_PUBLIC_FE_URL}/api/v1/mock`
-    : `${process.env.NEXT_PUBLIC_BE_URL}/api/v1`;
-
-export const apiUrl = makeUrl(apiBaseUrl);

--- a/one-day-hero/src/services/users.ts
+++ b/one-day-hero/src/services/users.ts
@@ -1,10 +1,9 @@
 import { UserResponse } from "@/types/response";
 
-import { apiUrl } from "./base";
+import { useFetch } from "./base";
 
-export const getUser = async (userId: number): Promise<UserResponse> => {
-  const response = await fetch(apiUrl(`/users/${userId}`), {
+export const useGetUserFetch = (userId: number) => {
+  return useFetch<UserResponse>(`/users/${userId}`, {
     next: { tags: [`user${userId}`] }
   });
-  return response.json();
 };

--- a/one-day-hero/src/services/users.ts
+++ b/one-day-hero/src/services/users.ts
@@ -1,6 +1,6 @@
 import { UserResponse } from "@/types/response";
 
-import { apiUrl } from "./urls";
+import { apiUrl } from "./base";
 
 export const getUser = async (userId: number): Promise<UserResponse> => {
   const response = await fetch(apiUrl(`/users/${userId}`), {

--- a/one-day-hero/src/types/response.ts
+++ b/one-day-hero/src/types/response.ts
@@ -54,6 +54,16 @@ export type SuggestedMissionListResponse = {
   serverDateTime: string;
 };
 
+export type BookmarkResponse = {
+  status: number;
+  data: {
+    id: number;
+    missionId: number;
+    userId: number;
+  };
+  serverDateTime: string;
+};
+
 export type UserResponse = {
   status: number;
   data: {


### PR DESCRIPTION
## 구현 내용
- SSR 환경에서 fetch 함수의 에러처리가 ErrorBoundary로 해결할 수 없어서 자체적으로 에러처리 기능을 추가했습니다.
  - `useFetch` 라는 이름으로 추상화했습니다. tanstack query의 `useQuery`를 따라했습니다.
  - fetch에 인자로 넣을 `pathname`과 `options`를 전달해 사용합니다.
  - fetch 완료 실행될 `callback`을 전달할 수 있습니다. revalidation에 사용하면 괜찮을 것 같아서 추가했습니다.
- fetch함수의 반환 값이 기존에는 응답 데이터였지만 지금은 `isError`라는 에러 여부 값과 `response` 값을 반환합니다.
  - `isError` 가 true 일 땐 `ErrorPage`를 서버에서 렌더링하도록 페이지들을 수정했습니다.
  - typescript의 추론을 위해 `isError` 조건에 `!response` 조건도 같이 검사합니다.
- POST, DELETE 등은 hook 규칙에 벗어나 조건문이나 handler 안에서 쓰여야할 경우가 많아서 `useMutationalFetch`로 분리했습니다.
  - tanstack query의 `useMutaion` 컨셉을 따왔습니다.
  - useFetch를 bind해서 조건부로 사용할 수 있도록 했습니다.


## 스크린샷
- 에러 페이지
>
<img width="371" alt="image" src="https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/54025398/c3c209fe-8e82-4842-826a-45e027074c96">

일단 간단히 만들었습니다.

## 궁금한 점
- 에러 페이지에서 `revalidatePath`를 쓰고 싶었는데 `Error: Invariant: static generation store missing in revalidateTag _N_T_{pathname}` 라는 알 수 없는 오류가 떠서 일단 삭제했습니다.
> 지금보니 분명 Path썼는데 Tag라고 에러 띄워주네요

- 더 세련된 방법이 있을지 궁금합니다..

## 이슈번호
- closes #122 
