### PR TITLE
이미지 업로드 컴포넌트 삭제 기능 추가

### DIFF
--- a/one-day-hero/package-lock.json
+++ b/one-day-hero/package-lock.json
@@ -8,13 +8,15 @@
       "name": "one-day-hero",
       "version": "0.1.0",
       "dependencies": {
+        "@types/uuid": "^9.0.7",
         "next": "13.5.6",
         "next-auth": "^4.24.4",
         "react": "^18",
         "react-calendar": "^4.6.1",
         "react-dom": "^18",
         "react-icons": "^4.11.0",
-        "sharp": "^0.32.6"
+        "sharp": "^0.32.6",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -281,6 +283,21 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz",
+      "integrity": "sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-linux-x64-musl": {
       "version": "13.5.6",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.6.tgz",
@@ -436,13 +453,13 @@
       "version": "15.7.10",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.10.tgz",
       "integrity": "sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.37",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.37.tgz",
       "integrity": "sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -462,13 +479,18 @@
       "version": "0.16.6",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.6.tgz",
       "integrity": "sha512-Vlktnchmkylvc9SnwwwozTv04L/e1NykF5vgoQ0XTmI8DD+wxfjQuHuvHS3p0r2jz2x2ghPs2h1FVeDirIteWA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
       "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.10.0",
@@ -1401,7 +1423,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3661,6 +3683,14 @@
         }
       }
     },
+    "node_modules/next-auth/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.51.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
@@ -5513,9 +5543,13 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -5708,21 +5742,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz",
-      "integrity": "sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/one-day-hero/package.json
+++ b/one-day-hero/package.json
@@ -10,13 +10,15 @@
     "prepare": "cd ../ && husky install ./one-day-hero/.husky"
   },
   "dependencies": {
+    "@types/uuid": "^9.0.7",
     "next": "13.5.6",
     "next-auth": "^4.24.4",
     "react": "^18",
     "react-calendar": "^4.6.1",
     "react-dom": "^18",
     "react-icons": "^4.11.0",
-    "sharp": "^0.32.6"
+    "sharp": "^0.32.6",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/one-day-hero/src/components/common/UploadImage.tsx
+++ b/one-day-hero/src/components/common/UploadImage.tsx
@@ -8,14 +8,18 @@ import {
   useRef,
   useState
 } from "react";
-import { BiCamera, BiX } from "react-icons/bi";
+import { BiCamera } from "react-icons/bi";
+import { HiOutlineTrash } from "react-icons/hi";
+import { v4 as uuidv4 } from "uuid";
+
+import { ImageFileType } from "@/types";
 
 import HorizontalScroll from "./HorizontalScroll";
 
 interface UploadImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   size?: "md" | "lg";
   // eslint-disable-next-line no-unused-vars
-  onFileSelect: (file: File[]) => void;
+  onFileSelect: (files: ImageFileType[]) => void;
 }
 
 const UploadImage = ({
@@ -24,7 +28,9 @@ const UploadImage = ({
   onFileSelect,
   ...props
 }: PropsWithChildren<UploadImageProps>) => {
-  const [selectedImages, setSelectedImages] = useState<File[] | null>(null);
+  const [selectedImages, setSelectedImages] = useState<ImageFileType[] | null>(
+    null
+  );
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const defaultStyle =
@@ -44,27 +50,32 @@ const UploadImage = ({
     inputRef?.current?.click();
   };
 
-  const handleDelete = (e: MouseEvent) => {
-    // 추후 구현 예정
+  const handleDelete = (id: string, e: MouseEvent) => {
     e.stopPropagation();
+    const newFile = selectedImages?.filter((image) => image.id !== id);
+    setSelectedImages(newFile ?? []);
   };
 
   const handleFileSelect = (event: ChangeEvent<HTMLInputElement>) => {
     if (event.target.files) {
+      const newFile = Array.from(event.target.files).map((file) => ({
+        id: uuidv4(),
+        file
+      }));
+
       if (size === "md") {
         if (
-          event.target.files.length > 3 ||
-          (selectedImages && selectedImages.length >= 3)
+          newFile.length > 3 ||
+          (selectedImages?.length ?? 0) + newFile.length > 3
         ) {
           alert("사진은 최대 3장입니다.");
           return;
         }
-        const newFile = Array.from(event.target.files);
+
         setSelectedImages((prev) =>
           prev ? [...prev, ...newFile] : [...newFile]
         );
       } else {
-        const newFile = Array.from(event.target.files);
         setSelectedImages(newFile);
       }
     }
@@ -95,22 +106,23 @@ const UploadImage = ({
           <div className="flex flex-col items-center justify-center">
             <BiCamera />
             {size === "md" && (
-              <p className="text-base">{selectedImages?.length ?? "0"} / 3</p>
+              <p className="text-base">{selectedImages?.length ?? 0} / 3</p>
             )}
           </div>
         </div>
         {selectedImages &&
           selectedImages.map((image) => (
             <div
-              key={image.name}
+              key={image.id}
               onClick={size === "lg" ? handleUpload : undefined}
               className={`${imageSizes[size]} shrink-0 overflow-hidden`}>
-              <BiX
-                className="absolute right-3 top-3 z-10 flex text-black"
-                onClick={handleDelete}
+              <HiOutlineTrash
+                size={size === "lg" ? 30 : 20}
+                className="absolute right-[6px] top-[6px] z-10 text-black"
+                onClick={(e: MouseEvent) => handleDelete(image.id, e)}
               />
               <Image
-                src={URL.createObjectURL(image)}
+                src={URL.createObjectURL(image.file)}
                 alt="올린 이미지"
                 fill
                 className="bg-cover"

--- a/one-day-hero/src/components/common/UploadImage.tsx
+++ b/one-day-hero/src/components/common/UploadImage.tsx
@@ -8,8 +8,7 @@ import {
   useRef,
   useState
 } from "react";
-import { BiCamera } from "react-icons/bi";
-import { HiOutlineTrash } from "react-icons/hi";
+import { BiCamera, BiX } from "react-icons/bi";
 import { v4 as uuidv4 } from "uuid";
 
 import { ImageFileType } from "@/types";
@@ -63,21 +62,20 @@ const UploadImage = ({
         file
       }));
 
-      if (size === "md") {
-        if (
-          newFile.length > 3 ||
-          (selectedImages?.length ?? 0) + newFile.length > 3
-        ) {
-          alert("사진은 최대 3장입니다.");
-          return;
-        }
-
-        setSelectedImages((prev) =>
-          prev ? [...prev, ...newFile] : [...newFile]
-        );
-      } else {
-        setSelectedImages(newFile);
+      if (
+        size === "md" &&
+        (newFile.length > 3 ||
+          (selectedImages?.length ?? 0) + newFile.length > 3)
+      ) {
+        alert(`사진은 최대 3장입니다.`);
+        return;
       }
+
+      setSelectedImages(
+        size === "md"
+          ? (prev) => (prev ? [...prev, ...newFile] : [...newFile])
+          : newFile
+      );
     }
   };
 
@@ -116,7 +114,7 @@ const UploadImage = ({
               key={image.id}
               onClick={size === "lg" ? handleUpload : undefined}
               className={`${imageSizes[size]} shrink-0 overflow-hidden`}>
-              <HiOutlineTrash
+              <BiX
                 size={size === "lg" ? 30 : 20}
                 className="absolute right-[6px] top-[6px] z-10 text-black"
                 onClick={(e: MouseEvent) => handleDelete(image.id, e)}

--- a/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
+++ b/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
@@ -11,6 +11,7 @@ import Textarea from "@/components/common/Textarea";
 import UploadImage from "@/components/common/UploadImage";
 import useFormValidation, { FormErrors } from "@/hooks/useFormValidation";
 import { apiUrl } from "@/services/base";
+import { ImageFileType } from "@/types";
 
 import CustomCalendar from "./CustomCalendar";
 
@@ -18,7 +19,9 @@ const hours = Array.from({ length: 24 }, (_, index) => index);
 
 const CreateForm = () => {
   const [categoryId, setCategoryId] = useState<number>(0);
-  const [selectedImages, setSelectedImages] = useState<File[] | null>(null);
+  const [selectedImages, setSelectedImages] = useState<ImageFileType[] | null>(
+    null
+  );
   const [errors, setErrors] = useState<FormErrors | null>(null);
   const titleRef = useRef<HTMLInputElement | null>(null);
   const dateRef = useRef<HTMLInputElement | null>(null);
@@ -32,7 +35,7 @@ const CreateForm = () => {
     setCategoryId(id);
   };
 
-  const handleFileSelect = (files: File[]) => {
+  const handleFileSelect = (files: ImageFileType[]) => {
     setSelectedImages(files);
   };
 

--- a/one-day-hero/src/components/domain/review/ReviewForm.tsx
+++ b/one-day-hero/src/components/domain/review/ReviewForm.tsx
@@ -6,6 +6,7 @@ import Container from "@/components/common/Container";
 import InputLabel from "@/components/common/InputLabel";
 import Textarea from "@/components/common/Textarea";
 import UploadImage from "@/components/common/UploadImage";
+import { ImageFileType } from "@/types";
 
 import StarRating from "./StarRating";
 
@@ -16,14 +17,16 @@ type ReviewFormProps = {
 
 const ReviewForm = ({ editMode }: ReviewFormProps) => {
   const [score, setScore] = useState<number>(0);
-  const [selectedImages, setSelectedImages] = useState<File[] | null>(null);
+  const [selectedImages, setSelectedImages] = useState<ImageFileType[] | null>(
+    null
+  );
   const reviewRef = useRef<HTMLTextAreaElement | null>(null);
 
   const handleScoreSelect = (count: number) => {
     setScore(count);
   };
 
-  const handleFileSelect = (files: File[]) => {
+  const handleFileSelect = (files: ImageFileType[]) => {
     setSelectedImages(files);
   };
 

--- a/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
@@ -8,11 +8,14 @@ import Input from "@/components/common/Input";
 import InputLabel from "@/components/common/InputLabel";
 import Textarea from "@/components/common/Textarea";
 import UploadImage from "@/components/common/UploadImage";
+import { ImageFileType } from "@/types";
 
 const MandatorySurvey = () => {
-  const [selectedImages, setSelectedImages] = useState<File[] | null>(null);
+  const [selectedImages, setSelectedImages] = useState<ImageFileType[] | null>(
+    null
+  );
 
-  const handleFileSelect = (files: File[]) => {
+  const handleFileSelect = (files: ImageFileType[]) => {
     setSelectedImages(files);
   };
 

--- a/one-day-hero/src/types/index.ts
+++ b/one-day-hero/src/types/index.ts
@@ -5,3 +5,8 @@ export type KebabMenuDataType = {
   description?: string;
   redirectTo?: string;
 };
+
+export type ImageFileType = {
+  id: string;
+  file: File;
+};


### PR DESCRIPTION
## 구현 내용
- 이미지 업로드 컴포넌트 이미지 파일에 고유한 아이디를 생성하여 업로드 후에도 지울 수 있도록 구현하였습니다.
- 각 페이지들에서는 타입 부분만 id를 추가한 타입으로 변경했습니다.
## 스크린샷

![스크린샷 2023-11-14 183751](https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/117630589/7babca21-9d1a-48a7-8e1d-c05ba3ced8ba)


## 궁금한 점
UploadImage 컴포넌트 조건문을 간결하게 써보려고 했는데 size가 md 일 때만 3개 이상인지 검사하는 조건이 들어가고 lg 사이즈면 multiple이 아닌 단일 파일 선택이라 그 자체를 상태값으로 넣어주고 있는데 제가 부족해서 그런지 잘 안되네요.. 좋은 방법이 있다면 알려주세요!!

## 이슈번호
- closes #132 
