### PR TITLE
카테고리 미선택 시 에러메세지 버그 수정

### DIFF
--- a/one-day-hero/src/components/common/Category.tsx
+++ b/one-day-hero/src/components/common/Category.tsx
@@ -74,26 +74,28 @@ const Category = ({
   }, [categoryActiveState, onSelect]);
 
   return (
-    <HorizontalScroll>
-      <ul className={`${containerStyle}`}>
-        {CATEGORY_LIST.map((category) => (
-          <div
-            key={category.id}
-            className={`${itemStyle} ${
-              categoryActiveState[category.id - 1] && "cs:bg-primary"
-            }`}
-            onClick={() => handleClick(category.id)}>
-            <IconGroup
-              title={category.title}
-              textSize="xs"
-              className="cs:text-3xl">
-              {category.icon}
-            </IconGroup>
-          </div>
-        ))}
-      </ul>
+    <div className="flex flex-col">
+      <HorizontalScroll>
+        <ul className={`${containerStyle}`}>
+          {CATEGORY_LIST.map((category) => (
+            <div
+              key={category.id}
+              className={`${itemStyle} ${
+                categoryActiveState[category.id - 1] && "cs:bg-primary"
+              }`}
+              onClick={() => handleClick(category.id)}>
+              <IconGroup
+                title={category.title}
+                textSize="xs"
+                className="cs:text-3xl">
+                {category.icon}
+              </IconGroup>
+            </div>
+          ))}
+        </ul>
+      </HorizontalScroll>
       {error && <ErrorMessage>{error}</ErrorMessage>}
-    </HorizontalScroll>
+    </div>
   );
 };
 


### PR DESCRIPTION
## 구현 내용
카테고리를 미선택 시 에러메세지가 가로스크롤에 부착되어 버리는 버그를 수정했습니다.

## 스크린샷
![스크린샷 2023-11-14 015916](https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/117630589/d5e28771-f7f0-46bd-8854-fc9c47288d70)

## 궁금한 점
가로 스크롤 자체에 `cs:flex-col` 을 줘서 해결하는 방법도 있었지만 가로 스크롤은 가로 스크롤 용도로만 사용하는게 좋겠다 하는 생각에 상단에 div를 생성하여 감싸줬습니다.

## 이슈번호
- closes #134 
