### PR TITLE
useMutationalFetch 로직 수정 및 유저 정보 수정 Mock api 작성

### DIFF
--- a/one-day-hero/src/app/api/v1/mock/_data/user/index.ts
+++ b/one-day-hero/src/app/api/v1/mock/_data/user/index.ts
@@ -1,4 +1,4 @@
-import { UserResponse } from "@/types/response";
+import { UserResponse, UserSummaryResponse } from "@/types/response";
 
 export const userDetail: UserResponse = {
   status: 200,
@@ -19,7 +19,27 @@ export const userDetail: UserResponse = {
       favoriteStartTime: "12:00",
       favoriteEndTime: "18:00"
     },
-    heroScore: 60
+    heroScore: 60,
+    isHeroMode: true
   },
-  serverDateTime: "2023-11-13T15:26:37"
+  serverDateTime: "2023-11-13T15:26:38"
+};
+
+export const userSummary: UserSummaryResponse = {
+  status: 200,
+  data: {
+    id: 1,
+    basicInfo: {
+      nickname: "이름",
+      gender: "MALE",
+      birth: "1990-01-01",
+      introduce: "자기소개"
+    },
+    favoriteWorkingDay: {
+      favoriteDate: ["MON", "THU"],
+      favoriteStartTime: "12:00",
+      favoriteEndTime: "18:00"
+    }
+  },
+  serverDateTime: "2023-11-13T15:26:38"
 };

--- a/one-day-hero/src/app/api/v1/mock/me/route.ts
+++ b/one-day-hero/src/app/api/v1/mock/me/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { userSummary } from "../_data/user";
+
+const userPatchSchema = z.object({
+  userId: z.number(),
+  basicInfo: z.object({
+    nickname: z.string(),
+    gender: z.string(),
+    birth: z.string(),
+    introduce: z.string()
+  }),
+  favoriteWorkingDay: z.object({
+    favoriteDate: z
+      .enum(["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"])
+      .array(),
+    favoriteStartTime: z.string(),
+    favoriteEndTime: z.string()
+  })
+});
+
+export async function PATCH(request: NextRequest) {
+  const userPatchData = await request.json();
+
+  const result = userPatchSchema.safeParse(userPatchData);
+
+  if (!result.success) {
+    return new NextResponse("Error", { status: 400 });
+  }
+
+  return NextResponse.json(userSummary, { status: 200 });
+}

--- a/one-day-hero/src/app/api/v1/mock/me/route.ts
+++ b/one-day-hero/src/app/api/v1/mock/me/route.ts
@@ -4,20 +4,25 @@ import { z } from "zod";
 import { userSummary } from "../_data/user";
 
 const userPatchSchema = z.object({
-  userId: z.number(),
-  basicInfo: z.object({
-    nickname: z.string(),
-    gender: z.string(),
-    birth: z.string(),
-    introduce: z.string()
-  }),
-  favoriteWorkingDay: z.object({
-    favoriteDate: z
-      .enum(["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"])
-      .array(),
-    favoriteStartTime: z.string(),
-    favoriteEndTime: z.string()
-  })
+  userId: z.number().optional(),
+  basicInfo: z
+    .object({
+      nickname: z.string().optional(),
+      gender: z.string().optional(),
+      birth: z.string().optional(),
+      introduce: z.string().optional()
+    })
+    .optional(),
+  favoriteWorkingDay: z
+    .object({
+      favoriteDate: z
+        .enum(["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"])
+        .array()
+        .optional(),
+      favoriteStartTime: z.string().optional(),
+      favoriteEndTime: z.string().optional()
+    })
+    .optional()
 });
 
 export async function PATCH(request: NextRequest) {

--- a/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
@@ -4,10 +4,12 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
 import { useForm } from "react-hook-form";
+import { v4 as uuidv4 } from "uuid";
 
 import Button from "@/components/common/Button";
 import InputLabel from "@/components/common/InputLabel";
 import UploadImage from "@/components/common/UploadImage";
+import { ImageFileType } from "@/types";
 import {
   MandatorySurveySchema,
   MandatorySurveySchemaProps
@@ -35,9 +37,12 @@ const MandatorySurvey = () => {
   };
 
   const handleFileSelect = useCallback(
-    (file: File[]) => {
+    (file: ImageFileType[]) => {
       clearErrors("image");
-      setValue("image", file);
+      setValue("image", {
+        id: uuidv4(),
+        file
+      });
     },
     [clearErrors, setValue]
   );
@@ -48,7 +53,7 @@ const MandatorySurvey = () => {
         onSubmit={handleSubmit(onSubmit)}
         className="mx-8 flex w-full max-w-screen-sm flex-col gap-7">
         <div>
-          <InputLabel className="cs:text-xl cs:ml-3" required>
+          <InputLabel className="cs:ml-3 cs:text-xl" required>
             프로필 사진
           </InputLabel>
           <UploadImage
@@ -62,12 +67,12 @@ const MandatorySurvey = () => {
         </div>
 
         <div>
-          <InputLabel className="cs:text-xl cs:ml-1 cs:mb-1" required>
+          <InputLabel className="cs:mb-1 cs:ml-1 cs:text-xl" required>
             닉네임
           </InputLabel>
           <input
             {...register("nickName")}
-            className="border-inactive focus:outline-primary placeholder:text-inactive h-11 w-full rounded-[10px] border p-4 pl-3"
+            className="h-11 w-full rounded-[10px] border border-inactive p-4 pl-3 placeholder:text-inactive focus:outline-primary"
           />
           {errors.nickName && (
             <p className="text-red-500">{`${errors.nickName.message}`}</p>
@@ -75,12 +80,12 @@ const MandatorySurvey = () => {
         </div>
 
         <div>
-          <InputLabel className="cs:text-xl cs:ml-1 cs:mb-1" required>
+          <InputLabel className="cs:mb-1 cs:ml-1 cs:text-xl" required>
             자기소개
           </InputLabel>
           <textarea
             {...register("introduction")}
-            className="border-inactive focus:outline-primary h-40 w-full max-w-screen-sm resize-none rounded-2xl border p-4"
+            className="h-40 w-full max-w-screen-sm resize-none rounded-2xl border border-inactive p-4 focus:outline-primary"
           />
           {errors.introduction && (
             <p className="text-red-500">{`${errors.introduction.message}`}</p>
@@ -90,7 +95,7 @@ const MandatorySurvey = () => {
         <Button
           disabled={isSubmitting}
           type="submit"
-          className="cs:mt-24 cs:mx-auto"
+          className="cs:mx-auto cs:mt-24"
           size="lg">
           다음
         </Button>

--- a/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { revalidateTag } from "next/cache";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
@@ -44,8 +43,7 @@ const MandatorySurvey = () => {
         })
       },
       () => {
-        revalidateTag(`user${123}`);
-        router.push("/servey/optional");
+        router.push("/survey/optional");
       }
     );
   };

--- a/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { revalidateTag } from "next/cache";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
-import { useForm } from "react-hook-form";
+import { SubmitHandler, useForm } from "react-hook-form";
 import { v4 as uuidv4 } from "uuid";
 
 import Button from "@/components/common/Button";
 import InputLabel from "@/components/common/InputLabel";
 import UploadImage from "@/components/common/UploadImage";
+import { useEditProfileFetch } from "@/services/users";
 import { ImageFileType } from "@/types";
 import {
   MandatorySurveySchema,
@@ -28,12 +30,24 @@ const MandatorySurvey = () => {
     resolver: zodResolver(MandatorySurveySchema)
   });
 
-  const onSubmit = () => {
-    if (errors) {
-      router.push("/survey/mandatory");
-    }
+  const { mutationalFetch } = useEditProfileFetch();
 
-    router.push("/survey/optional");
+  const onSubmit: SubmitHandler<MandatorySurveySchemaProps> = (data) => {
+    mutationalFetch(
+      {
+        method: "PATCH",
+        body: JSON.stringify({
+          basicInfo: {
+            nickname: data.nickName,
+            introduce: data.introduction
+          }
+        })
+      },
+      () => {
+        revalidateTag(`user${123}`);
+        router.push("/servey/optional");
+      }
+    );
   };
 
   const handleFileSelect = useCallback(

--- a/one-day-hero/src/services/users.ts
+++ b/one-day-hero/src/services/users.ts
@@ -1,3 +1,5 @@
+import { DeepPartial } from "@/types";
+import { UserEditRequest } from "@/types/request";
 import { UserResponse } from "@/types/response";
 
 import { useFetch, useMutationalFetch } from "./base";
@@ -30,6 +32,22 @@ export const useChangeCitizenFetch = (
     "/me/change-citizen",
     {
       method: "PATCH"
+    },
+    callback,
+    errorCallback
+  );
+};
+
+export const useEditProfileFetch = (
+  bodyData: DeepPartial<UserEditRequest>,
+  callback?: () => void,
+  errorCallback?: () => void
+) => {
+  return useMutationalFetch<UserResponse>(
+    "/me",
+    {
+      method: "PATCH",
+      body: JSON.stringify(bodyData)
     },
     callback,
     errorCallback

--- a/one-day-hero/src/services/users.ts
+++ b/one-day-hero/src/services/users.ts
@@ -1,8 +1,7 @@
-import { DeepPartial } from "@/types";
-import { UserEditRequest } from "@/types/request";
+/* eslint-disable no-unused-vars */
 import { UserResponse } from "@/types/response";
 
-import { useFetch, useMutationalFetch } from "./base";
+import { CustomResponse, useFetch, useMutationalFetch } from "./base";
 
 export const useGetUserFetch = (userId: number) => {
   return useFetch<UserResponse>(`/users/${userId}`, {
@@ -11,45 +10,39 @@ export const useGetUserFetch = (userId: number) => {
 };
 
 export const useChangeHeroFetch = (
-  callback?: () => void,
-  errorCallback?: () => void
+  onSuccess?: () => void,
+  onError?: () => void
 ) => {
   return useMutationalFetch<UserResponse>(
     "/me/change-hero",
     {
       method: "PATCH"
     },
-    callback,
-    errorCallback
+    onSuccess,
+    onError
   );
 };
 
 export const useChangeCitizenFetch = (
-  callback?: () => void,
-  errorCallback?: () => void
+  onSuccess?: () => void,
+  onError?: () => void
 ) => {
   return useMutationalFetch<UserResponse>(
     "/me/change-citizen",
     {
       method: "PATCH"
     },
-    callback,
-    errorCallback
+    onSuccess,
+    onError
   );
 };
 
-export const useEditProfileFetch = (
-  bodyData: DeepPartial<UserEditRequest>,
-  callback?: () => void,
-  errorCallback?: () => void
-) => {
-  return useMutationalFetch<UserResponse>(
-    "/me",
-    {
-      method: "PATCH",
-      body: JSON.stringify(bodyData)
-    },
-    callback,
-    errorCallback
-  );
+export const useEditProfileFetch = () => {
+  return useMutationalFetch<UserResponse>("/me") as {
+    mutationalFetch: (
+      fetchOptions: RequestInit,
+      onSuccess?: () => void,
+      onError?: () => void
+    ) => Promise<CustomResponse<UserResponse>>;
+  };
 };

--- a/one-day-hero/src/types/index.ts
+++ b/one-day-hero/src/types/index.ts
@@ -12,7 +12,3 @@ export type ImageFileType = {
 };
 
 export type DateType = "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN";
-
-export type DeepPartial<T> = {
-  [P in keyof T]?: DeepPartial<T[P]>;
-};

--- a/one-day-hero/src/types/index.ts
+++ b/one-day-hero/src/types/index.ts
@@ -10,3 +10,9 @@ export type ImageFileType = {
   id: string;
   file: File;
 };
+
+export type DateType = "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN";
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};

--- a/one-day-hero/src/types/request.ts
+++ b/one-day-hero/src/types/request.ts
@@ -1,0 +1,16 @@
+import { DateType } from ".";
+
+export type UserEditRequest = {
+  userId: number;
+  basicInfo: {
+    nickname: string;
+    gender: string;
+    birth: string;
+    introduce: string;
+  };
+  favoriteWorkingDay: {
+    favoriteDate: DateType[];
+    favoriteStartTime: string;
+    favoriteEndTime: string;
+  };
+};

--- a/one-day-hero/src/types/response.ts
+++ b/one-day-hero/src/types/response.ts
@@ -1,3 +1,5 @@
+import { DateType } from ".";
+
 export type MissionResponse = {
   status: number;
   data: {
@@ -64,15 +66,6 @@ export type BookmarkResponse = {
   serverDateTime: string;
 };
 
-export type DateResponse =
-  | "MON"
-  | "TUE"
-  | "WED"
-  | "THU"
-  | "FRI"
-  | "SAT"
-  | "SUN";
-
 export type UserResponse = {
   status: number;
   data: {
@@ -88,7 +81,7 @@ export type UserResponse = {
       path: string;
     };
     favoriteWorkingDay: {
-      favoriteDate: DateResponse[];
+      favoriteDate: DateType[];
       favoriteStartTime: string;
       favoriteEndTime: string;
     };
@@ -109,7 +102,7 @@ export type UserSummaryResponse = {
       introduce: string;
     };
     favoriteWorkingDay: {
-      favoriteDate: DateResponse[];
+      favoriteDate: DateType[];
       favoriteStartTime: string;
       favoriteEndTime: string;
     };

--- a/one-day-hero/src/types/response.ts
+++ b/one-day-hero/src/types/response.ts
@@ -64,6 +64,15 @@ export type BookmarkResponse = {
   serverDateTime: string;
 };
 
+export type DateResponse =
+  | "MON"
+  | "TUE"
+  | "WED"
+  | "THU"
+  | "FRI"
+  | "SAT"
+  | "SUN";
+
 export type UserResponse = {
   status: number;
   data: {
@@ -79,11 +88,31 @@ export type UserResponse = {
       path: string;
     };
     favoriteWorkingDay: {
-      favoriteDate: ("MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN")[];
+      favoriteDate: DateResponse[];
       favoriteStartTime: string;
       favoriteEndTime: string;
     };
     heroScore: number;
+    isHeroMode: boolean;
+  };
+  serverDateTime: string;
+};
+
+export type UserSummaryResponse = {
+  status: number;
+  data: {
+    id: number;
+    basicInfo: {
+      nickname: string;
+      gender: string;
+      birth: string;
+      introduce: string;
+    };
+    favoriteWorkingDay: {
+      favoriteDate: DateResponse[];
+      favoriteStartTime: string;
+      favoriteEndTime: string;
+    };
   };
   serverDateTime: string;
 };


### PR DESCRIPTION
## 구현 내용
- 유저 정보 수정 mock api를 만들었습니다.
  - 요청과 응답의 타입이 달라 따로 types에 저장했습니다.
  - body에 넣어주는 값을 체크할 수 있도록 route handler에 zod를 사용했습니다.
- `useMutationalFetch`의 로직을 수정했습니다.
  - 기존에는 선언할 때 fetch options나 callback 등의 인수를 넣고 사용하는 방식이었습니다.
  - 현재는 선언 때 받아온 `mutationalFetch`를 사용할 때 인수를 넣도록 수정했습니다.
  - submit handler에서 사용할 때 fetch options로 body를 넣어주면 됩니다.
  - 기존 callback이라고 이름 지어둔 인수는 onSuccess와 onError로 바꿨습니다.
- 수정한 로직을 `/survey/mandatory` 페이지에서 시험삼아 적용해봤습니다.
  - > 진경님이 작업 중인걸 미처 생각 못하고 REST 문서 맨 위 부터 작업해서 겹쳤습니다. 나중에 해당 페이지 구현 작업 머지되면 제가 충돌 처리해서 PR 수정하겠습니다.
  - 테스트 결과 지금 작동은 합니다.

## 스크린샷

## 궁금한 점
- onSuccess 에 revalidateTag 를 실행 시키려고 했더니 ISR어쩌구 하는 오류가 나더라고요. 왠지 느낌 상 클라이언트 컴포넌트에서 revalidation 쓰려면 route handler를 거쳐서 서버에서 revalidation을 실행 시켜야할 것 같네요.

## 이슈번호
- closes #143 
