### PR TITLE
pagenation api 용 usefetch 구현 및 진행중 미션 mock 데이터 업데이트

### DIFF
--- a/one-day-hero/src/app/api/v1/mock/_data/mission/index.ts
+++ b/one-day-hero/src/app/api/v1/mock/_data/mission/index.ts
@@ -1,6 +1,7 @@
 import {
   MissionResponse,
   OngoingMissionListResponse,
+  ProgressMissionListResponse,
   SuggestedMissionListResponse
 } from "@/types/response";
 
@@ -20,10 +21,8 @@ export const missionDetail: MissionResponse = {
       gu: "강남구",
       dong: "역삼동"
     },
-    location: {
-      x: 1234277.388,
-      y: 1234252.23
-    },
+    longitude: 1234277.388,
+    latitude: 1234252.23,
     missionInfo: {
       title: "제목",
       content:
@@ -45,6 +44,52 @@ export const missionDetail: MissionResponse = {
   serverDateTime: "2023-11-02T14:25:44"
 };
 
+export const progessMissionList: ProgressMissionListResponse = {
+  status: 200,
+  data: {
+    missionProgressResponses: {
+      content: [
+        {
+          id: 1,
+          title: "제목",
+          missionCategory: {
+            id: 1,
+            code: "MC_001",
+            name: "서빙"
+          },
+          missionDate: "2023-11-06",
+          bookmarkCount: 1,
+          missionStatus: "MATCHING"
+        }
+      ],
+      pageable: {
+        pageNumber: 0,
+        pageSize: 4,
+        sort: {
+          empty: true,
+          sorted: false,
+          unsorted: true
+        },
+        offset: 0,
+        paged: true,
+        unpaged: false
+      },
+      size: 4,
+      number: 0,
+      sort: {
+        empty: true,
+        sorted: false,
+        unsorted: true
+      },
+      first: true,
+      last: true,
+      numberOfElements: 1,
+      empty: false
+    }
+  },
+  serverDateTime: "2023-11-13T15:26:37"
+};
+
 export const ongoingMissionList: OngoingMissionListResponse = {
   status: 200,
   data: [
@@ -62,10 +107,8 @@ export const ongoingMissionList: OngoingMissionListResponse = {
         gu: "마포구",
         dong: "동교동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "더미 데이터 제목입니다.",
         content: "내용1",
@@ -97,10 +140,8 @@ export const ongoingMissionList: OngoingMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목11",
         content: "내용11",
@@ -132,10 +173,8 @@ export const ongoingMissionList: OngoingMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목111",
         content: "내용111",
@@ -167,10 +206,8 @@ export const ongoingMissionList: OngoingMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목2",
         content: "내용2",
@@ -202,10 +239,8 @@ export const ongoingMissionList: OngoingMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목3",
         content: "내용3",
@@ -237,10 +272,8 @@ export const ongoingMissionList: OngoingMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목4",
         content: "내용4",
@@ -272,10 +305,8 @@ export const ongoingMissionList: OngoingMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목5",
         content: "내용5",
@@ -307,10 +338,8 @@ export const ongoingMissionList: OngoingMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목6",
         content: "내용6",
@@ -349,10 +378,8 @@ export const suggestedMissionList: SuggestedMissionListResponse = {
         gu: "마포구",
         dong: "동교동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "더미 데이터 제목입니다.",
         content: "내용1",
@@ -384,10 +411,8 @@ export const suggestedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목11",
         content: "내용11",
@@ -419,10 +444,8 @@ export const suggestedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목111",
         content: "내용111",
@@ -454,10 +477,8 @@ export const suggestedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목2",
         content: "내용2",
@@ -489,10 +510,8 @@ export const suggestedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목3",
         content: "내용3",
@@ -524,10 +543,8 @@ export const suggestedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목4",
         content: "내용4",
@@ -559,10 +576,8 @@ export const suggestedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목5",
         content: "내용5",
@@ -594,10 +609,8 @@ export const suggestedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목6",
         content: "내용6",
@@ -637,10 +650,8 @@ export const completedMissionList: SuggestedMissionListResponse = {
         gu: "마포구",
         dong: "동교동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "더미 데이터 제목입니다.",
         content: "내용1",
@@ -672,10 +683,8 @@ export const completedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목11",
         content: "내용11",
@@ -707,10 +716,8 @@ export const completedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목111",
         content: "내용111",
@@ -742,10 +749,8 @@ export const completedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목2",
         content: "내용2",
@@ -777,10 +782,8 @@ export const completedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목3",
         content: "내용3",
@@ -812,10 +815,8 @@ export const completedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목4",
         content: "내용4",
@@ -847,10 +848,8 @@ export const completedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목5",
         content: "내용5",
@@ -882,10 +881,8 @@ export const completedMissionList: SuggestedMissionListResponse = {
         gu: "강남구",
         dong: "역삼동"
       },
-      location: {
-        x: 1234252.23,
-        y: 1234252.23
-      },
+      longitude: 1234277.388,
+      latitude: 1234252.23,
       missionInfo: {
         title: "제목6",
         content: "내용6",

--- a/one-day-hero/src/app/api/v1/mock/_data/mission/index.ts
+++ b/one-day-hero/src/app/api/v1/mock/_data/mission/index.ts
@@ -47,10 +47,34 @@ export const missionDetail: MissionResponse = {
 export const progessMissionList: ProgressMissionListResponse = {
   status: 200,
   data: {
-    missionProgressResponses: {
+    response: {
       content: [
         {
           id: 1,
+          title: "제목",
+          missionCategory: {
+            id: 1,
+            code: "MC_001",
+            name: "서빙"
+          },
+          missionDate: "2023-11-06",
+          bookmarkCount: 1,
+          missionStatus: "MATCHING"
+        },
+        {
+          id: 2,
+          title: "제목",
+          missionCategory: {
+            id: 1,
+            code: "MC_001",
+            name: "서빙"
+          },
+          missionDate: "2023-11-06",
+          bookmarkCount: 1,
+          missionStatus: "MATCHING"
+        },
+        {
+          id: 3,
           title: "제목",
           missionCategory: {
             id: 1,

--- a/one-day-hero/src/app/api/v1/mock/_data/user/index.ts
+++ b/one-day-hero/src/app/api/v1/mock/_data/user/index.ts
@@ -1,4 +1,4 @@
-import { UserResponse } from "@/types/response";
+import { UserResponse, UserSummaryResponse } from "@/types/response";
 
 export const userDetail: UserResponse = {
   status: 200,
@@ -19,7 +19,27 @@ export const userDetail: UserResponse = {
       favoriteStartTime: "12:00",
       favoriteEndTime: "18:00"
     },
-    heroScore: 60
+    heroScore: 60,
+    isHeroMode: true
   },
-  serverDateTime: "2023-11-13T15:26:37"
+  serverDateTime: "2023-11-13T15:26:38"
+};
+
+export const userSummary: UserSummaryResponse = {
+  status: 200,
+  data: {
+    id: 1,
+    basicInfo: {
+      nickname: "이름",
+      gender: "MALE",
+      birth: "1990-01-01",
+      introduce: "자기소개"
+    },
+    favoriteWorkingDay: {
+      favoriteDate: ["MON", "THU"],
+      favoriteStartTime: "12:00",
+      favoriteEndTime: "18:00"
+    }
+  },
+  serverDateTime: "2023-11-13T15:26:38"
 };

--- a/one-day-hero/src/app/api/v1/mock/me/route.ts
+++ b/one-day-hero/src/app/api/v1/mock/me/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { userSummary } from "../_data/user";
+
+const userPatchSchema = z.object({
+  userId: z.number(),
+  basicInfo: z.object({
+    nickname: z.string(),
+    gender: z.string(),
+    birth: z.string(),
+    introduce: z.string()
+  }),
+  favoriteWorkingDay: z.object({
+    favoriteDate: z
+      .enum(["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"])
+      .array(),
+    favoriteStartTime: z.string(),
+    favoriteEndTime: z.string()
+  })
+});
+
+export async function PATCH(request: NextRequest) {
+  const userPatchData = await request.json();
+
+  const result = userPatchSchema.safeParse(userPatchData);
+
+  if (!result.success) {
+    return new NextResponse("Error", { status: 400 });
+  }
+
+  return NextResponse.json(userSummary, { status: 200 });
+}

--- a/one-day-hero/src/app/api/v1/mock/me/route.ts
+++ b/one-day-hero/src/app/api/v1/mock/me/route.ts
@@ -4,20 +4,25 @@ import { z } from "zod";
 import { userSummary } from "../_data/user";
 
 const userPatchSchema = z.object({
-  userId: z.number(),
-  basicInfo: z.object({
-    nickname: z.string(),
-    gender: z.string(),
-    birth: z.string(),
-    introduce: z.string()
-  }),
-  favoriteWorkingDay: z.object({
-    favoriteDate: z
-      .enum(["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"])
-      .array(),
-    favoriteStartTime: z.string(),
-    favoriteEndTime: z.string()
-  })
+  userId: z.number().optional(),
+  basicInfo: z
+    .object({
+      nickname: z.string().optional(),
+      gender: z.string().optional(),
+      birth: z.string().optional(),
+      introduce: z.string().optional()
+    })
+    .optional(),
+  favoriteWorkingDay: z
+    .object({
+      favoriteDate: z
+        .enum(["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"])
+        .array()
+        .optional(),
+      favoriteStartTime: z.string().optional(),
+      favoriteEndTime: z.string().optional()
+    })
+    .optional()
 });
 
 export async function PATCH(request: NextRequest) {

--- a/one-day-hero/src/app/api/v1/mock/missions/progress/[slug]/route.ts
+++ b/one-day-hero/src/app/api/v1/mock/missions/progress/[slug]/route.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { progessMissionList } from "../../../_data/mission";
+
+export function GET(
+  request: NextRequest,
+  { params }: { params: { slug: string } }
+) {
+  const userId = params.slug;
+
+  const searchParams = request.nextUrl.searchParams;
+  const page = searchParams.get("page");
+  const size = searchParams.get("size");
+  const sort = searchParams.get("sort");
+
+  return NextResponse.json(progessMissionList, { status: 200 });
+}

--- a/one-day-hero/src/app/mission/list/ongoing/page.tsx
+++ b/one-day-hero/src/app/mission/list/ongoing/page.tsx
@@ -1,6 +1,6 @@
-import { getServerSession } from "next-auth";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
 
 import authOptions from "@/app/api/auth/[...nextauth]/authOptions";
 import ErrorPage from "@/app/error";
@@ -10,11 +10,11 @@ import { useGetOngoingMissionListFetch } from "@/services/missions";
 import { MissionResponse } from "@/types/response";
 
 const OngoingMissionPage = async () => {
-  const session = await getServerSession(authOptions);
+  // const session = await getServerSession(authOptions);
 
-  if (!session) {
-    redirect("/api/auth/signin?callbackUrl=/mission/list/ongoing");
-  }
+  // if (!session) {
+  //   redirect("/api/auth/signin?callbackUrl=/mission/list/ongoing");
+  // }
 
   const { isError, response } = await useGetOngoingMissionListFetch();
 

--- a/one-day-hero/src/app/mission/list/ongoing/page.tsx
+++ b/one-day-hero/src/app/mission/list/ongoing/page.tsx
@@ -1,3 +1,4 @@
+import { revalidateTag } from "next/cache";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
@@ -6,7 +7,10 @@ import authOptions from "@/app/api/auth/[...nextauth]/authOptions";
 import ErrorPage from "@/app/error";
 import MissionListItem from "@/components/common/Info/MissionListItem";
 import MissionProgressContainer from "@/components/common/MissionProgressContainer";
-import { useGetOngoingMissionListFetch } from "@/services/missions";
+import {
+  useGetOngoingMissionListFetch,
+  useGetProgressMissionListFetch
+} from "@/services/missions";
 import { MissionResponse } from "@/types/response";
 
 const OngoingMissionPage = async () => {
@@ -15,33 +19,31 @@ const OngoingMissionPage = async () => {
   // if (!session) {
   //   redirect("/api/auth/signin?callbackUrl=/mission/list/ongoing");
   // }
+  /**@note mock 데이터 수정사항 반영 용도 */
+  revalidateTag("progress123");
 
-  const { isError, response } = await useGetOngoingMissionListFetch();
-
-  if (isError || !response) return <ErrorPage />;
-
-  const { data } = response;
+  const { data, fetchNextPage, hasNextPage } =
+    await useGetProgressMissionListFetch("123");
 
   return (
     <div className="mt-20 w-full max-w-screen-sm space-y-4">
-      {data &&
-        data.map((item: MissionResponse["data"]) => (
-          <Link
-            href={`/mission/${item.id}`}
-            className="flex w-full max-w-screen-sm justify-center"
-            key={item.id}>
-            <MissionProgressContainer missionStatus={item.missionStatus}>
-              <MissionListItem
-                className="cs:p-4"
-                categories={item.missionCategory.name}
-                createAt={item.missionInfo.missionDate}
-                location="구 동"
-                title={item.missionInfo.title}
-                bookmarkCount={item.bookmarkCount}
-              />
-            </MissionProgressContainer>
-          </Link>
-        ))}
+      {data.map((item) => (
+        <Link
+          href={`/mission/${item.id}`}
+          className="flex w-full max-w-screen-sm justify-center"
+          key={item.id}>
+          <MissionProgressContainer missionStatus={item.missionStatus}>
+            <MissionListItem
+              className="cs:p-4"
+              categories={item.missionCategory.name}
+              createAt={item.missionDate}
+              location="구 동"
+              title={item.title}
+              bookmarkCount={item.bookmarkCount}
+            />
+          </MissionProgressContainer>
+        </Link>
+      ))}
     </div>
   );
 };

--- a/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
@@ -4,10 +4,12 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
 import { useForm } from "react-hook-form";
+import { v4 as uuidv4 } from "uuid";
 
 import Button from "@/components/common/Button";
 import InputLabel from "@/components/common/InputLabel";
 import UploadImage from "@/components/common/UploadImage";
+import { ImageFileType } from "@/types";
 import {
   MandatorySurveySchema,
   MandatorySurveySchemaProps
@@ -35,9 +37,12 @@ const MandatorySurvey = () => {
   };
 
   const handleFileSelect = useCallback(
-    (file: File[]) => {
+    (file: ImageFileType[]) => {
       clearErrors("image");
-      setValue("image", file);
+      setValue("image", {
+        id: uuidv4(),
+        file
+      });
     },
     [clearErrors, setValue]
   );
@@ -48,7 +53,7 @@ const MandatorySurvey = () => {
         onSubmit={handleSubmit(onSubmit)}
         className="mx-8 flex w-full max-w-screen-sm flex-col gap-7">
         <div>
-          <InputLabel className="cs:text-xl cs:ml-3" required>
+          <InputLabel className="cs:ml-3 cs:text-xl" required>
             프로필 사진
           </InputLabel>
           <UploadImage
@@ -62,12 +67,12 @@ const MandatorySurvey = () => {
         </div>
 
         <div>
-          <InputLabel className="cs:text-xl cs:ml-1 cs:mb-1" required>
+          <InputLabel className="cs:mb-1 cs:ml-1 cs:text-xl" required>
             닉네임
           </InputLabel>
           <input
             {...register("nickName")}
-            className="border-inactive focus:outline-primary placeholder:text-inactive h-11 w-full rounded-[10px] border p-4 pl-3"
+            className="h-11 w-full rounded-[10px] border border-inactive p-4 pl-3 placeholder:text-inactive focus:outline-primary"
           />
           {errors.nickName && (
             <p className="text-red-500">{`${errors.nickName.message}`}</p>
@@ -75,12 +80,12 @@ const MandatorySurvey = () => {
         </div>
 
         <div>
-          <InputLabel className="cs:text-xl cs:ml-1 cs:mb-1" required>
+          <InputLabel className="cs:mb-1 cs:ml-1 cs:text-xl" required>
             자기소개
           </InputLabel>
           <textarea
             {...register("introduction")}
-            className="border-inactive focus:outline-primary h-40 w-full max-w-screen-sm resize-none rounded-2xl border p-4"
+            className="h-40 w-full max-w-screen-sm resize-none rounded-2xl border border-inactive p-4 focus:outline-primary"
           />
           {errors.introduction && (
             <p className="text-red-500">{`${errors.introduction.message}`}</p>
@@ -90,7 +95,7 @@ const MandatorySurvey = () => {
         <Button
           disabled={isSubmitting}
           type="submit"
-          className="cs:mt-24 cs:mx-auto"
+          className="cs:mx-auto cs:mt-24"
           size="lg">
           다음
         </Button>

--- a/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { revalidateTag } from "next/cache";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
@@ -44,8 +43,7 @@ const MandatorySurvey = () => {
         })
       },
       () => {
-        revalidateTag(`user${123}`);
-        router.push("/servey/optional");
+        router.push("/survey/optional");
       }
     );
   };

--- a/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { revalidateTag } from "next/cache";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
-import { useForm } from "react-hook-form";
+import { SubmitHandler, useForm } from "react-hook-form";
 import { v4 as uuidv4 } from "uuid";
 
 import Button from "@/components/common/Button";
 import InputLabel from "@/components/common/InputLabel";
 import UploadImage from "@/components/common/UploadImage";
+import { useEditProfileFetch } from "@/services/users";
 import { ImageFileType } from "@/types";
 import {
   MandatorySurveySchema,
@@ -28,12 +30,24 @@ const MandatorySurvey = () => {
     resolver: zodResolver(MandatorySurveySchema)
   });
 
-  const onSubmit = () => {
-    if (errors) {
-      router.push("/survey/mandatory");
-    }
+  const { mutationalFetch } = useEditProfileFetch();
 
-    router.push("/survey/optional");
+  const onSubmit: SubmitHandler<MandatorySurveySchemaProps> = (data) => {
+    mutationalFetch(
+      {
+        method: "PATCH",
+        body: JSON.stringify({
+          basicInfo: {
+            nickname: data.nickName,
+            introduce: data.introduction
+          }
+        })
+      },
+      () => {
+        revalidateTag(`user${123}`);
+        router.push("/servey/optional");
+      }
+    );
   };
 
   const handleFileSelect = useCallback(

--- a/one-day-hero/src/services/missions.ts
+++ b/one-day-hero/src/services/missions.ts
@@ -4,10 +4,11 @@ import {
   BookmarkResponse,
   MissionResponse,
   OngoingMissionListResponse,
+  ProgressMissionListResponse,
   SuggestedMissionListResponse
 } from "@/types/response";
 
-import { useFetch, useMutationalFetch } from "./base";
+import { useFetch, useInfiniteFetch, useMutationalFetch } from "./base";
 
 export const useGetMissionFetch = (missionId: string) => {
   return useFetch<MissionResponse>(`/missions/${missionId}`, {
@@ -59,4 +60,14 @@ export const useGetSuggestedMissionListFetch = () => {
   return useFetch<SuggestedMissionListResponse>(`/missions/list/suggested`, {
     next: { tags: [`suggested`] }
   });
+};
+
+export const useGetProgressMissionListFetch = (userId: string) => {
+  return useInfiniteFetch<ProgressMissionListResponse>(
+    `/missions/progress/${userId}`,
+    3,
+    {
+      next: { tags: [`progress${userId}`] }
+    }
+  );
 };

--- a/one-day-hero/src/services/users.ts
+++ b/one-day-hero/src/services/users.ts
@@ -1,3 +1,5 @@
+import { DeepPartial } from "@/types";
+import { UserEditRequest } from "@/types/request";
 import { UserResponse } from "@/types/response";
 
 import { useFetch, useMutationalFetch } from "./base";
@@ -30,6 +32,22 @@ export const useChangeCitizenFetch = (
     "/me/change-citizen",
     {
       method: "PATCH"
+    },
+    callback,
+    errorCallback
+  );
+};
+
+export const useEditProfileFetch = (
+  bodyData: DeepPartial<UserEditRequest>,
+  callback?: () => void,
+  errorCallback?: () => void
+) => {
+  return useMutationalFetch<UserResponse>(
+    "/me",
+    {
+      method: "PATCH",
+      body: JSON.stringify(bodyData)
     },
     callback,
     errorCallback

--- a/one-day-hero/src/services/users.ts
+++ b/one-day-hero/src/services/users.ts
@@ -1,8 +1,7 @@
-import { DeepPartial } from "@/types";
-import { UserEditRequest } from "@/types/request";
+/* eslint-disable no-unused-vars */
 import { UserResponse } from "@/types/response";
 
-import { useFetch, useMutationalFetch } from "./base";
+import { CustomResponse, useFetch, useMutationalFetch } from "./base";
 
 export const useGetUserFetch = (userId: number) => {
   return useFetch<UserResponse>(`/users/${userId}`, {
@@ -11,45 +10,39 @@ export const useGetUserFetch = (userId: number) => {
 };
 
 export const useChangeHeroFetch = (
-  callback?: () => void,
-  errorCallback?: () => void
+  onSuccess?: () => void,
+  onError?: () => void
 ) => {
   return useMutationalFetch<UserResponse>(
     "/me/change-hero",
     {
       method: "PATCH"
     },
-    callback,
-    errorCallback
+    onSuccess,
+    onError
   );
 };
 
 export const useChangeCitizenFetch = (
-  callback?: () => void,
-  errorCallback?: () => void
+  onSuccess?: () => void,
+  onError?: () => void
 ) => {
   return useMutationalFetch<UserResponse>(
     "/me/change-citizen",
     {
       method: "PATCH"
     },
-    callback,
-    errorCallback
+    onSuccess,
+    onError
   );
 };
 
-export const useEditProfileFetch = (
-  bodyData: DeepPartial<UserEditRequest>,
-  callback?: () => void,
-  errorCallback?: () => void
-) => {
-  return useMutationalFetch<UserResponse>(
-    "/me",
-    {
-      method: "PATCH",
-      body: JSON.stringify(bodyData)
-    },
-    callback,
-    errorCallback
-  );
+export const useEditProfileFetch = () => {
+  return useMutationalFetch<UserResponse>("/me") as {
+    mutationalFetch: (
+      fetchOptions: RequestInit,
+      onSuccess?: () => void,
+      onError?: () => void
+    ) => Promise<CustomResponse<UserResponse>>;
+  };
 };

--- a/one-day-hero/src/types/index.ts
+++ b/one-day-hero/src/types/index.ts
@@ -12,7 +12,3 @@ export type ImageFileType = {
 };
 
 export type DateType = "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN";
-
-export type DeepPartial<T> = {
-  [P in keyof T]?: DeepPartial<T[P]>;
-};

--- a/one-day-hero/src/types/index.ts
+++ b/one-day-hero/src/types/index.ts
@@ -10,3 +10,9 @@ export type ImageFileType = {
   id: string;
   file: File;
 };
+
+export type DateType = "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN";
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};

--- a/one-day-hero/src/types/request.ts
+++ b/one-day-hero/src/types/request.ts
@@ -1,0 +1,16 @@
+import { DateType } from ".";
+
+export type UserEditRequest = {
+  userId: number;
+  basicInfo: {
+    nickname: string;
+    gender: string;
+    birth: string;
+    introduce: string;
+  };
+  favoriteWorkingDay: {
+    favoriteDate: DateType[];
+    favoriteStartTime: string;
+    favoriteEndTime: string;
+  };
+};

--- a/one-day-hero/src/types/response.ts
+++ b/one-day-hero/src/types/response.ts
@@ -1,3 +1,5 @@
+import { DateType } from ".";
+
 export type MissionResponse = {
   status: number;
   data: {
@@ -64,15 +66,6 @@ export type BookmarkResponse = {
   serverDateTime: string;
 };
 
-export type DateResponse =
-  | "MON"
-  | "TUE"
-  | "WED"
-  | "THU"
-  | "FRI"
-  | "SAT"
-  | "SUN";
-
 export type UserResponse = {
   status: number;
   data: {
@@ -88,7 +81,7 @@ export type UserResponse = {
       path: string;
     };
     favoriteWorkingDay: {
-      favoriteDate: DateResponse[];
+      favoriteDate: DateType[];
       favoriteStartTime: string;
       favoriteEndTime: string;
     };
@@ -109,7 +102,7 @@ export type UserSummaryResponse = {
       introduce: string;
     };
     favoriteWorkingDay: {
-      favoriteDate: DateResponse[];
+      favoriteDate: DateType[];
       favoriteStartTime: string;
       favoriteEndTime: string;
     };

--- a/one-day-hero/src/types/response.ts
+++ b/one-day-hero/src/types/response.ts
@@ -16,10 +16,8 @@ export type MissionResponse = {
       gu: string;
       dong: string;
     };
-    location: {
-      x: number;
-      y: number;
-    };
+    longitude: number;
+    latitude: number;
     missionInfo: {
       title: string;
       content: string;
@@ -39,6 +37,50 @@ export type MissionResponse = {
     missionImage: {
       originalName: string;
       path: string;
+    };
+  };
+  serverDateTime: string;
+};
+
+export type ProgressMissionListResponse = {
+  status: number;
+  data: {
+    missionProgressResponses: {
+      content: {
+        id: number;
+        title: string;
+        missionCategory: {
+          id: number;
+          code: string;
+          name: string;
+        };
+        missionDate: string;
+        bookmarkCount: number;
+        missionStatus: string;
+      }[];
+      pageable: {
+        pageNumber: number;
+        pageSize: number;
+        sort: {
+          empty: boolean;
+          sorted: boolean;
+          unsorted: boolean;
+        };
+        offset: number;
+        paged: boolean;
+        unpaged: boolean;
+      };
+      size: 4;
+      number: number;
+      sort: {
+        empty: boolean;
+        sorted: boolean;
+        unsorted: boolean;
+      };
+      first: boolean;
+      last: boolean;
+      numberOfElements: number;
+      empty: boolean;
     };
   };
   serverDateTime: string;

--- a/one-day-hero/src/types/response.ts
+++ b/one-day-hero/src/types/response.ts
@@ -64,6 +64,15 @@ export type BookmarkResponse = {
   serverDateTime: string;
 };
 
+export type DateResponse =
+  | "MON"
+  | "TUE"
+  | "WED"
+  | "THU"
+  | "FRI"
+  | "SAT"
+  | "SUN";
+
 export type UserResponse = {
   status: number;
   data: {
@@ -79,11 +88,31 @@ export type UserResponse = {
       path: string;
     };
     favoriteWorkingDay: {
-      favoriteDate: ("MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN")[];
+      favoriteDate: DateResponse[];
       favoriteStartTime: string;
       favoriteEndTime: string;
     };
     heroScore: number;
+    isHeroMode: boolean;
+  };
+  serverDateTime: string;
+};
+
+export type UserSummaryResponse = {
+  status: number;
+  data: {
+    id: number;
+    basicInfo: {
+      nickname: string;
+      gender: string;
+      birth: string;
+      introduce: string;
+    };
+    favoriteWorkingDay: {
+      favoriteDate: DateResponse[];
+      favoriteStartTime: string;
+      favoriteEndTime: string;
+    };
   };
   serverDateTime: string;
 };

--- a/one-day-hero/src/types/response.ts
+++ b/one-day-hero/src/types/response.ts
@@ -45,7 +45,7 @@ export type MissionResponse = {
 export type ProgressMissionListResponse = {
   status: number;
   data: {
-    missionProgressResponses: {
+    response: {
       content: {
         id: number;
         title: string;
@@ -56,7 +56,11 @@ export type ProgressMissionListResponse = {
         };
         missionDate: string;
         bookmarkCount: number;
-        missionStatus: string;
+        missionStatus:
+          | "MATCHING"
+          | "MATCHING_COMPLETED"
+          | "MISSION_COMPLETED"
+          | "EXPIRED";
       }[];
       pageable: {
         pageNumber: number;


### PR DESCRIPTION
## 구현 내용
- pagenation 방식으로 응답이 내려오는 API 용 fetch 함수인 `useInfiniteFetch` 를 구현했습니다.
  - 첫 데이터가 오는 것만 확인했는데 다음 값이 data에 추가돼서 반영될 지는 실제 api에서 테스트해봐야 할 것 같습니다.
  - 반환 메서드의 이름은 tanstack query를 참고했습니다.
  - 현재 응답 값의 필드 이름(`missionProgressResponses` 등)이 제각각인데 `response`로 통합한다는 가정하에 작성했습니다.
- 진행중인 미션 페이지에 반영해서 테스트 해보았습니다.

## 스크린샷

## 궁금한 점
- 무한스크롤을 intersection observer로 구현할지.. 일단 더보기 버튼만 대충 넣을지.. 고민이 되네요

## 이슈번호
- closes #145 
