### PR TITLE
공용 toast 컴포넌트 구현

### DIFF
--- a/one-day-hero/src/app/layout.tsx
+++ b/one-day-hero/src/app/layout.tsx
@@ -4,6 +4,8 @@ import type { Metadata } from "next";
 import { Noto_Sans_KR } from "next/font/google";
 
 import { Providers } from "@/components/common/Oauth/Providers";
+import Toast from "@/components/common/Toast";
+import ToastProvider from "@/contexts/ToastProvider";
 
 const notoSansKR = Noto_Sans_KR({
   subsets: ["latin"],
@@ -23,11 +25,14 @@ export default function RootLayout({
   return (
     <html lang="kr">
       <body className={`${notoSansKR.className} flex flex-col items-center`}>
-        <Providers>
-          <main className="bg-background flex min-h-screen w-full max-w-screen-sm flex-col items-center px-5 py-24 shadow">
-            {children}
-          </main>
-        </Providers>
+        <ToastProvider>
+          <Providers>
+            <main className="bg-background flex min-h-screen w-full max-w-screen-sm flex-col items-center px-5 py-24 shadow">
+              {children}
+            </main>
+          </Providers>
+          <Toast />
+        </ToastProvider>
       </body>
     </html>
   );

--- a/one-day-hero/src/components/common/Toast.tsx
+++ b/one-day-hero/src/components/common/Toast.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+import { FaCheckCircle } from "react-icons/fa";
+import { PiWarningCircleFill } from "react-icons/pi";
+import { TiDelete } from "react-icons/ti";
+
+import { useToast } from "@/contexts/ToastProvider";
+
+const defaultStyle =
+  "shadow-down w-[300px] rounded-2xl font-semibold opacity-80 bg-white border border-gray-200 fixed inset-x-1/2 translate-x-[-50%] z-50";
+
+const Toast = () => {
+  const { toastActive, toastMessage, toastType } = useToast();
+
+  useEffect(() => {
+    if (!toastActive) return;
+  }, [toastActive]);
+
+  const iconType = {
+    success: <FaCheckCircle size={22} className="text-primary" />,
+    warn: <PiWarningCircleFill size={22} className="text-sub" />,
+    error: <TiDelete size={22} className="text-red-600" />
+  };
+
+  return (
+    <>
+      {toastActive && (
+        <div className={`${defaultStyle} animate-show-toast`}>
+          <div className="flex items-center gap-3 p-4">
+            <div className="flex-shrink-0">{iconType[toastType]}</div>
+            <div className="text-sm text-gray-700">{toastMessage}</div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default Toast;

--- a/one-day-hero/src/components/common/UploadImage.tsx
+++ b/one-day-hero/src/components/common/UploadImage.tsx
@@ -11,6 +11,7 @@ import {
 import { BiCamera, BiX } from "react-icons/bi";
 import { v4 as uuidv4 } from "uuid";
 
+import { useToast } from "@/contexts/ToastProvider";
 import { ImageFileType } from "@/types";
 
 import HorizontalScroll from "./HorizontalScroll";
@@ -31,6 +32,7 @@ const UploadImage = ({
     null
   );
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const { showToast } = useToast();
 
   const defaultStyle =
     "bg-inactive text-white flex justify-center items-center shrink-0";
@@ -55,9 +57,9 @@ const UploadImage = ({
     setSelectedImages(newFile ?? []);
   };
 
-  const handleFileSelect = (event: ChangeEvent<HTMLInputElement>) => {
-    if (event.target.files) {
-      const newFile = Array.from(event.target.files).map((file) => ({
+  const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      const newFile = Array.from(e.target.files).map((file) => ({
         id: uuidv4(),
         file
       }));
@@ -67,7 +69,8 @@ const UploadImage = ({
         (newFile.length > 3 ||
           (selectedImages?.length ?? 0) + newFile.length > 3)
       ) {
-        alert(`사진은 최대 3장입니다.`);
+        e.target.value = "";
+        showToast("최대 3개까지 선택 가능합니다.", "error");
         return;
       }
 

--- a/one-day-hero/src/contexts/ToastProvider.tsx
+++ b/one-day-hero/src/contexts/ToastProvider.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+
+type ToastContextType = {
+  // eslint-disable-next-line no-unused-vars
+  showToast: (message: string, type: "warn" | "error" | "success") => void;
+  hideToast?: () => void;
+  toastActive: boolean;
+  toastMessage: string;
+  toastType: "warn" | "error" | "success";
+};
+
+const ToastContext = createContext<ToastContextType | null>(null);
+
+const ToastProvider = ({ children }: { children: React.ReactNode }) => {
+  const [toastActive, setToastActive] = useState<boolean>(false);
+  const [toastMessage, setToastMessage] = useState<string>("");
+  const [toastType, setToastType] = useState<"warn" | "error" | "success">(
+    "success"
+  );
+
+  const showToast = (message: string, type: "warn" | "error" | "success") => {
+    setToastActive(true);
+    setToastMessage(message);
+    setToastType(type);
+
+    setTimeout(() => {
+      setToastActive(false);
+    }, 3000);
+  };
+
+  const hideToast = () => {
+    setToastActive(false);
+  };
+
+  return (
+    <ToastContext.Provider
+      value={{ showToast, hideToast, toastActive, toastMessage, toastType }}>
+      {children}
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (context === null) {
+    throw new Error("Toast Context 코드를 다시 확인해주세요.");
+  }
+  return context;
+};
+
+export default ToastProvider;

--- a/one-day-hero/tailwind.config.ts
+++ b/one-day-hero/tailwind.config.ts
@@ -51,6 +51,16 @@ const config: Config = {
       screens: {
         cs: "0px"
       }
+    },
+    keyframes: {
+      "show-toast": {
+        "0%": { bottom: "8%" },
+        "70%": { bottom: "8%" },
+        "100%": { bottom: "0" }
+      }
+    },
+    animation: {
+      "show-toast": "show-toast 3s ease-in-out"
     }
   },
   plugins: []


### PR DESCRIPTION
## 구현 내용
공용으로 사용될 Toast UI를 구현했습니다.

사용할 부분에서 `const { showToast } = useToast()` 로 불러와준 후 showToast 에 매개변수로 첫 번째는 에러메세지, 두 번째는
warn, error, success 셋 중 하나의 타입을 설정해 주시면 됩니다!

`showToast('이건 테스트입니다', 'warn')`

## 스크린샷

https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/117630589/adf9e3b3-5ca4-4b6f-b473-3761390b0048

## 궁금한 점
`context`를 이용하는 방법과 react portal을 이용하는 방법이 있었는데 사용하는 컴포넌트 단에서 context api를 사용하면 좀 더 간단하게 사용할 수 있을 것 같아서 context로 구현했는데 괜찮을까요??

루트 레이아웃 진경님이 구현해주신 Provider 상단에 Toast Provider를 배치했는데 위치가 괜찮을 지 모르겠네요..

일단은 1개만 사용되도록 구현했는데 배열로 만들면 여러 개를 띄울수도 있을 것 같더라구요..

## 이슈번호
- closes #147 
