### PR TITLE
프로필 조사 폼선택 클라이언트 단 내부 로직

### DIFF
--- a/one-day-hero/package-lock.json
+++ b/one-day-hero/package-lock.json
@@ -19,6 +19,7 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
+        "@hookform/resolvers": "^3.3.2",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -36,8 +37,10 @@
         "lint-staged": "^15.0.2",
         "postcss": "^8",
         "prettier": "^3.0.3",
+        "react-hook-form": "^7.48.2",
         "tailwindcss": "^3",
-        "typescript": "^5"
+        "typescript": "^5",
+        "zod": "^3.22.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -126,6 +129,15 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.2.tgz",
+      "integrity": "sha512-Tw+GGPnBp+5DOsSg4ek3LCPgkBOuOgS5DsDV7qsWNH9LZc433kgsWICjlsh2J9p04H2K66hsXPPb9qn9ILdUtA==",
+      "dev": true,
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -453,13 +465,13 @@
       "version": "15.7.10",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.10.tgz",
       "integrity": "sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.2.37",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.37.tgz",
       "integrity": "sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -479,7 +491,7 @@
       "version": "0.16.6",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.6.tgz",
       "integrity": "sha512-Vlktnchmkylvc9SnwwwozTv04L/e1NykF5vgoQ0XTmI8DD+wxfjQuHuvHS3p0r2jz2x2ghPs2h1FVeDirIteWA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.5",
@@ -1423,7 +1435,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4434,6 +4446,22 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.48.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.48.2.tgz",
+      "integrity": "sha512-H0T2InFQb1hX7qKtDIZmvpU1Xfn/bdahWBN1fH19gSe4bBEqTfmlr7H3XWTaVtiK4/tpPaI1F3355GPMZYge+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.11.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
@@ -5742,6 +5770,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/one-day-hero/src/app/api/v1/mock/_data/survey/index.ts
+++ b/one-day-hero/src/app/api/v1/mock/_data/survey/index.ts
@@ -1,0 +1,42 @@
+import { favoriteRegionsResponse } from "@/types/response";
+
+export const favoriteRegionsData: favoriteRegionsResponse = {
+  서울시: [
+    {
+      강남구: [
+        {
+          regionId: 1,
+          dong: "역삼동"
+        },
+        {
+          regionId: 2,
+          dong: "삼성동"
+        }
+      ]
+    },
+    {
+      강동구: [
+        {
+          regionId: 3,
+          dong: "천호동"
+        },
+        {
+          regionId: 4,
+          dong: "길동"
+        }
+      ]
+    },
+    {
+      진경구: [
+        {
+          regionId: 1,
+          dong: "진경동"
+        },
+        {
+          regionId: 2,
+          dong: "갱동"
+        }
+      ]
+    }
+  ]
+};

--- a/one-day-hero/src/app/survey/category/page.tsx
+++ b/one-day-hero/src/app/survey/category/page.tsx
@@ -1,0 +1,5 @@
+const CategorySurveyPage = () => {
+  return <div>CategorySurveyPage</div>;
+};
+
+export default CategorySurveyPage;

--- a/one-day-hero/src/components/common/DayList.tsx
+++ b/one-day-hero/src/components/common/DayList.tsx
@@ -1,15 +1,45 @@
+import { forwardRef, PropsWithChildren } from "react";
+import {
+  FieldValues,
+  UseFormGetValues,
+  UseFormSetValue
+} from "react-hook-form";
+
 import ToggleButton from "./ToggleButton";
 
-const DayList = () => {
-  const days = ["월", "화", "수", "목", "금", "토", "일"];
-
-  return (
-    <div className="flex flex-wrap gap-x-1.5">
-      {days.map((day, index) => (
-        <ToggleButton key={index}>{day}</ToggleButton>
-      ))}
-    </div>
-  );
+type DayListProps = {
+  getValues: UseFormGetValues<FieldValues>;
+  setValue: UseFormSetValue<FieldValues>;
+  className?: "";
 };
+
+const DayList = forwardRef(
+  (
+    {
+      className,
+      getValues,
+      setValue,
+      ...props
+    }: PropsWithChildren<DayListProps>,
+    ref
+  ) => {
+    const days = ["월", "화", "수", "목", "금", "토", "일"];
+
+    return (
+      <div className={`${className} flex flex-wrap gap-x-1.5`} {...props}>
+        {days.map((day, index) => (
+          <ToggleButton
+            setValue={setValue}
+            getValues={getValues}
+            key={index}
+            selectedDate={day}
+          />
+        ))}
+      </div>
+    );
+  }
+);
+
+DayList.displayName = "DayList";
 
 export default DayList;

--- a/one-day-hero/src/components/common/Select.tsx
+++ b/one-day-hero/src/components/common/Select.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ForwardedRef, forwardRef, PropsWithChildren } from "react";
+import { FieldValues, UseFormSetValue } from "react-hook-form";
 
 import useForm from "@/hooks/useForm";
 
@@ -9,11 +10,19 @@ import ErrorMessage from "./ErrorMessage";
 interface SelectProps extends React.ComponentProps<"select"> {
   className?: string;
   error?: string;
+  setValue?: UseFormSetValue<FieldValues>;
 }
 
 const Select = forwardRef(
   (
-    { id, className, children, error }: PropsWithChildren<SelectProps>,
+    {
+      id,
+      className,
+      setValue,
+      children,
+      error,
+      ...props
+    }: PropsWithChildren<SelectProps>,
     ref: ForwardedRef<HTMLSelectElement>
   ) => {
     const { handleChange } = useForm("");
@@ -29,7 +38,9 @@ const Select = forwardRef(
           onChange={handleChange}
           className={`${defaultStyle} ${className} ${
             error && "border-2 border-red-500"
-          }`}>
+          }`}
+          {...props}>
+          <option value="">선택</option>
           {children}
         </select>
         {error && <ErrorMessage>{error}</ErrorMessage>}

--- a/one-day-hero/src/components/common/ToggleButton.tsx
+++ b/one-day-hero/src/components/common/ToggleButton.tsx
@@ -1,16 +1,46 @@
 "use client";
 
-import { useState } from "react";
+import { PropsWithChildren, useCallback, useState } from "react";
+import {
+  FieldValues,
+  UseFormGetValues,
+  UseFormSetValue
+} from "react-hook-form";
+
+type ToggleButtonProps = {
+  className?: "";
+  selectedDate: string;
+  setValue: UseFormSetValue<FieldValues>;
+  getValues: UseFormGetValues<FieldValues>;
+};
 
 const ToggleButton = ({
   children,
-  className
-}: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+  className,
+  setValue,
+  getValues,
+  selectedDate,
+  ...props
+}: PropsWithChildren<ToggleButtonProps>) => {
   const [clicked, setClicked] = useState<boolean>(false);
 
-  const handleButtonClick = () => {
+  const handleButtonClick = useCallback(() => {
+    const setArray = () => {
+      const prevArray = getValues("favoriteWorkingDay.favoriteDate") || [];
+
+      const updatedArray = prevArray.includes(selectedDate)
+        ? prevArray.filter((day: string) => day !== selectedDate)
+        : [...prevArray, selectedDate];
+
+      return updatedArray;
+    };
+
+    const test = setArray();
+
+    setValue("favoriteWorkingDay.favoriteDate", test);
+
     setClicked(!clicked);
-  };
+  }, [setValue, clicked, getValues, selectedDate]);
 
   const defaultStyle = "w-11 h-11 text-base text-black rounded-lg border";
 
@@ -18,11 +48,12 @@ const ToggleButton = ({
     <button
       className={`${defaultStyle} ${
         clicked
-          ? "border-4 border-primary bg-primary-lightest"
+          ? "border-primary bg-primary-lightest border-4"
           : "border-background-darken bg-white"
       } ${className}`}
-      onClick={handleButtonClick}>
-      {children}
+      onClick={handleButtonClick}
+      {...props}>
+      {selectedDate}
     </button>
   );
 };

--- a/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
@@ -2,18 +2,19 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
-import { useCallback } from "react";
+import React, { useCallback } from "react";
 import { useForm } from "react-hook-form";
 
 import Button from "@/components/common/Button";
 import InputLabel from "@/components/common/InputLabel";
 import UploadImage from "@/components/common/UploadImage";
+import { ImageFileType } from "@/types";
 import {
   MandatorySurveySchema,
   MandatorySurveySchemaProps
 } from "@/types/schema";
 
-const MandatorySurvey = () => {
+const MandatorySurvey = React.forwardRef(() => {
   const router = useRouter();
 
   const {
@@ -35,7 +36,7 @@ const MandatorySurvey = () => {
   };
 
   const handleFileSelect = useCallback(
-    (file: File[]) => {
+    (file: ImageFileType[]) => {
       clearErrors("image");
       setValue("image", file);
     },
@@ -97,6 +98,8 @@ const MandatorySurvey = () => {
       </form>
     </>
   );
-};
+});
+
+MandatorySurvey.displayName = "MandatorySurvey";
 
 export default MandatorySurvey;

--- a/one-day-hero/src/components/domain/survey/OptionalSurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/OptionalSurvey.tsx
@@ -1,30 +1,118 @@
 "use client";
 
-import Link from "next/link";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { ChangeEvent, useEffect, useState } from "react";
+import { FieldValues, SubmitHandler, useForm } from "react-hook-form";
 import { AiOutlineClose, AiOutlinePlus } from "react-icons/ai";
 import { PiWaveSineBold } from "react-icons/pi";
 
+import { favoriteRegionsData } from "@/app/api/v1/mock/_data/survey";
 import Button from "@/components/common/Button";
 import DayList from "@/components/common/DayList";
 import HorizontalScroll from "@/components/common/HorizontalScroll";
 import InputLabel from "@/components/common/InputLabel";
 import Label from "@/components/common/Label";
+import LinkButton from "@/components/common/LinkButton";
 import Select from "@/components/common/Select";
+import { OptionalSurveySchema } from "@/types/schema";
 
 const OptionalSurvey = () => {
+  const [favoriteGu, setFavoriteGu] = useState<string>("");
+  const [favoriteDong, setFavoriteDong] = useState<string>("");
+  const [favoriteDongId, setFavoriteDongId] = useState<number>(0);
+  const [favoriteRegions, setFavoriteRegions] = useState<string[]>([]);
+  const [favoriteRegionsId, setFavoriteRegionsId] = useState<number[]>([]);
+
+  const { register, handleSubmit, setValue, getValues } = useForm({
+    resolver: zodResolver(OptionalSurveySchema)
+  });
+
   const hours = Array.from({ length: 24 }, (_, index) =>
     index < 10 ? "0" + index : index
   );
 
+  const seoulGu = favoriteRegionsData["서울시"].map(
+    (region) => Object.keys(region)[0]
+  );
+
+  const seoulDong = favoriteRegionsData["서울시"].filter(
+    (region) => favoriteGu in region
+  )?.[0]?.[favoriteGu];
+
+  useEffect(() => {
+    setValue("favoriteRegions", [...favoriteRegionsId]);
+  }, [favoriteRegionsId, setValue]);
+
+  const handleAddFavoriteRegion = () => {
+    const selectedGuDong = favoriteGu + " " + favoriteDong;
+
+    if (favoriteDongId === 0 || favoriteGu === "") {
+      return;
+    }
+
+    if (favoriteRegions.includes(selectedGuDong)) {
+      alert("이미 선택한 지역입니다."); /**@note toast로 바꿀 예정 */
+      return;
+    }
+
+    if (favoriteRegions.length === 5) {
+      alert(
+        "선호지역은 최대 5개 선택할 수 있습니다."
+      ); /**@note toast로 바꿀 예정 */
+    }
+
+    setFavoriteRegions([...favoriteRegions, selectedGuDong]);
+    setFavoriteRegionsId([...favoriteRegionsId, favoriteDongId]);
+  };
+
+  const handleRemoveFavoriteRegion = () => {
+    const updatedFavoriteRegions = favoriteRegions.slice(
+      0,
+      favoriteRegions.length - 1
+    );
+    const updatedFavoriteRegionsId = favoriteRegionsId.slice(
+      0,
+      favoriteRegionsId.length - 1
+    );
+
+    setFavoriteRegions(updatedFavoriteRegions);
+    setFavoriteRegionsId(updatedFavoriteRegionsId);
+
+    setValue("FavoriteRegions", updatedFavoriteRegionsId);
+  };
+
+  const handleGuChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    setFavoriteGu(e.target.value);
+  };
+
+  const handleDongChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    setFavoriteDong(
+      e.target.options[e.target.selectedIndex].dataset.dong ?? ""
+    );
+
+    setFavoriteDongId(Number(e.target.value));
+  };
+
+  const onSubmit: SubmitHandler<FieldValues> = (data) => {
+    console.log("data", data); /** @note 서버로 보낼때 사용할 것 같습니다.  */
+  };
+
   return (
     <>
-      <form className="flex w-full max-w-screen-sm flex-col gap-12">
+      <form
+        onSubmit={handleSubmit(onSubmit, onSubmit)}
+        className="flex w-full max-w-screen-sm flex-col gap-8">
         <div>
           <InputLabel className="cs:text-xl cs:ml-1 cs:mb-1">
             희망 근무일
           </InputLabel>
-          <DayList />
+          <DayList
+            {...register("favoriteWorkingDay.favoriteDate")}
+            setValue={setValue}
+            getValues={getValues}
+          />
         </div>
+
         <div>
           <InputLabel
             htmlFor="working hour"
@@ -32,17 +120,25 @@ const OptionalSurvey = () => {
             희망 근무시간
           </InputLabel>
           <div className="mt-1 flex gap-2">
-            <Select id="working hour">
+            <Select
+              id="working hour start"
+              setValue={setValue}
+              {...register("favoriteWorkingDay.favoriteStartTime")}>
               {hours.map((hour) => (
                 <option className="text-xs" key={hour}>
                   {hour}:00
                 </option>
               ))}
             </Select>
+
             <span className="text-bold my-auto">
               <PiWaveSineBold />
             </span>
-            <Select id="working hour">
+
+            <Select
+              id="working hour end"
+              setValue={setValue}
+              {...register("favoriteWorkingDay.favoriteEndTime")}>
               {hours.map((hour) => (
                 <option className="text-xs" key={hour}>
                   {hour}:00
@@ -51,6 +147,7 @@ const OptionalSurvey = () => {
             </Select>
           </div>
         </div>
+
         <div>
           <InputLabel
             htmlFor="favorite region"
@@ -58,61 +155,74 @@ const OptionalSurvey = () => {
             선호지역(최대 5개)
           </InputLabel>
           <div className="mt-1 flex gap-2">
-            <Select id="favorite region">
-              {["마포구", "땡땡구"].map((gu) => (
-                <option className="text-xs" key={gu}>
+            <Select id="favorite gu" onChange={handleGuChange}>
+              {seoulGu.map((gu) => (
+                <option className="text-xs" key={gu} value={gu}>
                   {gu}
                 </option>
               ))}
             </Select>
-            <span className="text-bold my-auto">
-              <PiWaveSineBold />
-            </span>
-            <Select id="favorite region">
-              {["동교동", "땡땡동"].map((dong) => (
-                <option className="text-xs" key={dong}>
-                  {dong}
-                </option>
-              ))}
+
+            <Select id="favorite dong" onChange={handleDongChange}>
+              {seoulDong &&
+                seoulDong.map(
+                  ({ regionId, dong }: { regionId: number; dong: string }) => (
+                    <option
+                      className="text-xs"
+                      key={regionId}
+                      value={regionId}
+                      data-dong={dong}>
+                      {dong}
+                    </option>
+                  )
+                )}
             </Select>
+
             <Button
               theme="primary"
-              className="h-9 w-9 rounded-xl px-3 text-white">
+              className="cs:h-9 cs:w-9 cs:rounded-xl cs:px-3 cs:text-white"
+              onClick={handleAddFavoriteRegion}>
               <AiOutlinePlus className="pr-4 text-3xl" />
             </Button>
+            <Button
+              theme="primary"
+              className="cs:h-9 cs:w-9 cs:rounded-xl cs:px-3 cs:text-white"
+              onClick={handleRemoveFavoriteRegion}>
+              <AiOutlineClose className="pr-4 text-3xl" />
+            </Button>
           </div>
+
           <HorizontalScroll className="cs:mt-2">
-            {[
-              "마포구 동교동",
-              "땡땡구 땡땡동",
-              "와와구 와와동",
-              "이러구 저러동",
-              "마포구 동교동",
-              "땡땡구 땡땡동",
-              "와와구 와와동",
-              "이러구 저러동"
-            ].map((region) => (
-              <Label key={region} size="md" className="cs:min-w-fit cs:mr-2">
-                {region}
-                <AiOutlineClose className="ml-1" />
-              </Label>
-            ))}
+            {favoriteRegions &&
+              favoriteRegions.map((region: string) => (
+                <Label
+                  key={region}
+                  size="md"
+                  className="cs:min-w-fit cs:px-3 cs:mr-2">
+                  {region}
+                </Label>
+              ))}
           </HorizontalScroll>
         </div>
+
         <div className="bg-cancel-lighten h-56 w-full rounded-2xl">
           지도자리
         </div>
-        <div className="flex w-full">
-          <Link href="/survey/optional" className="cs:grow">
-            <Button theme="cancel" size="md">
-              건너뛰기
-            </Button>
-          </Link>
-          <Link href="/survey/optional" className="cs:grow">
-            <Button size="md" className="cs:w-full">
-              다음
-            </Button>
-          </Link>
+
+        <div className="mt-12 flex w-full">
+          <LinkButton
+            theme="cancel"
+            href="/"
+            showChevron={false}
+            className="cs:grow cs:m-2">
+            건너뛰기
+          </LinkButton>
+          <LinkButton
+            href="/survey/category"
+            className="cs:grow cs:m-2"
+            showChevron={false}>
+            <Button type="submit">다음</Button>
+          </LinkButton>
         </div>
       </form>
     </>

--- a/one-day-hero/src/types/response.ts
+++ b/one-day-hero/src/types/response.ts
@@ -87,3 +87,16 @@ export type UserResponse = {
   };
   serverDateTime: string;
 };
+
+type dong = {
+  regionId: number;
+  dong: string;
+};
+
+type gu = {
+  [key: string]: dong[] | undefined;
+};
+
+export type favoriteRegionsResponse = {
+  서울시: gu[];
+};

--- a/one-day-hero/src/types/schema.ts
+++ b/one-day-hero/src/types/schema.ts
@@ -19,3 +19,12 @@ export const MandatorySurveySchema = z.object({
 });
 
 export type MandatorySurveySchemaProps = z.infer<typeof MandatorySurveySchema>;
+
+export const OptionalSurveySchema = z.object({
+  favoriteWorkingDay: z.object({
+    favoriteDate: z.array(z.string()),
+    favoriteStartTime: z.string(),
+    favoriteEndTime: z.string()
+  }),
+  favoriteRegions: z.array(z.number()).max(5)
+});


### PR DESCRIPTION
## 구현 내용
프로필 조사 폼 선택 클라이언트 단 내부 로직 구현했습니다. 

> 자잘하게 올라가 있는 파일들이 많은데 OptionalSurvey 컴포넌트만 봐주시면 됩니다. 

react-hook-form 과 zod를 이용해서 type과 스키마를 지정해주고 select 항목마다 검사할 수 있게 구현했습니다. 

선택한 선호지역을 삭제하는 기능에 관해서 고민을 많이 해봤는데, UI측면에서 클릭한 선호지역 라벨을 삭제하는 건 가능하나, 서버에 보낼 선호지역 id 배열 값에서 또한 삭제하려면 클릭하는 라벨 부분에서도 id 값을 뽑아올 수 있어야 합니다. 그러면  id와 구+동 값을 담고있는 객체 배열 구조로 구조를 바꿔야 할 것 같아 조금 진행해 봤는데 로직이 너무 복잡해 지는 것 같았습니다. 

그래서 대안으로 가장 마지막에 들어온 선호지역 id값에 대해서 삭제를 하는 쪽으로 구현해봤는데 괜찮을까요?? 
혹시 아이디어가 있으시면 공유해주세요!


이미 선택한 선호지역일 경우 와 선호지역이 5개가 넘어가게 되는 경우 우선 alert가 뜨게 했는데 추후 toast로 바꾸겠습니다. 

<img width="400" alt="Screenshot 2023-11-17 at 3 10 46 AM" src="https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/99384699/f758848f-30d6-4a5c-9cd2-552369ee1971">

<img width="400" alt="Screenshot 2023-11-17 at 3 11 11 AM" src="https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/99384699/573e265d-e7c5-423e-82cc-fcbc237a86c4">

## 스크린샷
https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/99384699/4fba9f7c-4ef9-44c5-a3af-eaa25fd79d37

## 궁금한 점
수평스크롤 컴포넌트가 마우스로 click drag 가 안되는데 혹시 따로 부여해야 하는 속성이 있을까요??

## 이슈번호
- closes #
