### PR TITLE
프로필 페이지들 데이터 업데이트

### DIFF
--- a/one-day-hero/src/app/api/v1/mock/_data/user/index.ts
+++ b/one-day-hero/src/app/api/v1/mock/_data/user/index.ts
@@ -19,6 +19,20 @@ export const userDetail: UserResponse = {
       favoriteStartTime: "12:00",
       favoriteEndTime: "18:00"
     },
+    favoriteRegions: [
+      {
+        id: 1,
+        si: "서울시",
+        gu: "강남구",
+        dong: "역삼동"
+      },
+      {
+        id: 2,
+        si: "서울시",
+        gu: "강남구",
+        dong: "청담동"
+      }
+    ],
     heroScore: 60,
     isHeroMode: true
   },

--- a/one-day-hero/src/app/citizenProfile/[slug]/page.tsx
+++ b/one-day-hero/src/app/citizenProfile/[slug]/page.tsx
@@ -18,7 +18,7 @@ const CitizenProfilePage = async ({ params }: { params: { slug: string } }) => {
   if (isError || !response) return <ErrorPage />;
 
   const {
-    data: { basicInfo }
+    data: { basicInfo, heroScore }
   } = response;
 
   return (
@@ -48,7 +48,7 @@ const CitizenProfilePage = async ({ params }: { params: { slug: string } }) => {
             ))}
           </HelpCircle>
         </div>
-        <HeroScore score={70} />
+        <HeroScore score={heroScore} />
       </div>
       <LinkButton href="/mission/record" className="cs:mb-3 cs:w-full">
         리뷰

--- a/one-day-hero/src/app/heroProfile/[slug]/page.tsx
+++ b/one-day-hero/src/app/heroProfile/[slug]/page.tsx
@@ -4,7 +4,6 @@ import DefaultThumbnail from "/public/images/OneDayHero_logo_sm.svg";
 import ErrorPage from "@/app/error";
 import { calculateAge, parseGender } from "@/app/utils/formatProfile";
 import HeroScore from "@/components/common/HeroScore";
-import Label from "@/components/common/Label";
 import LinkButton from "@/components/common/LinkButton";
 import FavoriteDateList from "@/components/domain/profile/FavoriteDateList";
 import HelpCircle from "@/components/domain/profile/HelpCircle";
@@ -18,15 +17,16 @@ const HeroProfilePage = async ({ params }: { params: { slug: string } }) => {
   );
 
   if (isError || !response) return <ErrorPage />;
+
   const {
-    data: { basicInfo, favoriteWorkingDay }
+    data: { basicInfo, image, favoriteWorkingDay, favoriteRegions, heroScore }
   } = response;
 
   return (
     <>
       <div className="flex w-full">
         <Image
-          src={DefaultThumbnail}
+          src={image.path || DefaultThumbnail}
           alt="썸네일"
           width={150}
           className="pointer-events-none mr-3 rounded-full bg-neutral-200"
@@ -49,7 +49,7 @@ const HeroProfilePage = async ({ params }: { params: { slug: string } }) => {
             ))}
           </HelpCircle>
         </div>
-        <HeroScore score={70} />
+        <HeroScore score={heroScore} />
       </div>
       <div className="w-full">
         <div className="mb-2 mt-5 flex items-center">
@@ -69,18 +69,20 @@ const HeroProfilePage = async ({ params }: { params: { slug: string } }) => {
       <div className="w-full">
         <h2 className="mb-2 mt-5 text-xl font-semibold">선호 지역</h2>
         <div className="rounded-lg border border-background-darken bg-white p-2">
-          서울시 강남구 역삼동
+          {favoriteRegions?.map(({ id, si, gu, dong }) => (
+            <p key={id}>{`${si} ${gu} ${dong}`}</p>
+          ))}
         </div>
       </div>
       <div className="mb-12 w-full">
         <h2 className="mb-2 mt-5 text-xl font-semibold">소개</h2>
         <div className="rounded-lg border border-background-darken bg-white p-2">
-          <div className="mb-2 flex gap-2">
+          {/* <div className="mb-2 flex gap-2">
             <Label size="lg">카페</Label>
             <Label size="lg">식당</Label>
             <Label size="lg">청소</Label>
-          </div>
-          <p>식당 알바 6개월 경력</p>
+          </div> */}
+          <p>{basicInfo.introduce}</p>
         </div>
       </div>
       <LinkButton href="/mission/record" className="cs:mb-3 cs:w-full">

--- a/one-day-hero/src/app/profile/page.tsx
+++ b/one-day-hero/src/app/profile/page.tsx
@@ -18,14 +18,21 @@ const ProfilePage = async () => {
   if (isError || !response) return <ErrorPage />;
 
   const {
-    data: { basicInfo, favoriteWorkingDay }
+    data: {
+      basicInfo,
+      image,
+      favoriteWorkingDay,
+      favoriteRegions,
+      heroScore,
+      isHeroMode
+    }
   } = response;
 
   return (
     <>
       <div className="flex w-full">
         <Image
-          src={DefaultThumbnail}
+          src={image.path || DefaultThumbnail}
           alt="썸네일"
           width={150}
           className="pointer-events-none mr-3 rounded-full bg-neutral-200"
@@ -46,7 +53,7 @@ const ProfilePage = async () => {
             {HELP_MESSAGES.HERO_MODE_CHANGE}
           </HelpCircle>
         </div>
-        <HeroSwitch isHeroMode={false} />
+        <HeroSwitch isHeroMode={!!isHeroMode} />
       </div>
 
       <div className="w-full">
@@ -58,7 +65,7 @@ const ProfilePage = async () => {
             ))}
           </HelpCircle>
         </div>
-        <HeroScore score={70} />
+        <HeroScore score={heroScore} />
       </div>
       <div className="w-full">
         <div className="mb-2 mt-5 flex items-center">
@@ -78,18 +85,20 @@ const ProfilePage = async () => {
       <div className="w-full">
         <h2 className="mb-2 mt-5 text-xl font-semibold">선호 지역</h2>
         <div className="rounded-lg border border-background-darken bg-white p-2">
-          서울시 강남구 역삼동
+          {favoriteRegions?.map(({ id, si, gu, dong }) => (
+            <p key={id}>{`${si} ${gu} ${dong}`}</p>
+          ))}
         </div>
       </div>
       <div className="mb-12 w-full">
         <h2 className="mb-2 mt-5 text-xl font-semibold">소개</h2>
         <div className="rounded-lg border border-background-darken bg-white p-2">
-          <div className="mb-2 flex gap-2">
+          {/* <div className="mb-2 flex gap-2">
             <Label size="lg">카페</Label>
             <Label size="lg">식당</Label>
             <Label size="lg">청소</Label>
-          </div>
-          <p>식당 알바 6개월 경력</p>
+          </div> */}
+          <p>{basicInfo.introduce}</p>
         </div>
       </div>
       <LinkButton href="/mission/record" className="cs:mb-3 cs:w-full">

--- a/one-day-hero/src/types/response.ts
+++ b/one-day-hero/src/types/response.ts
@@ -187,8 +187,14 @@ export type UserResponse = {
       favoriteStartTime: string;
       favoriteEndTime: string;
     };
+    favoriteRegions?: {
+      id: number;
+      si: string;
+      gu: string;
+      dong: string;
+    }[];
     heroScore: number;
-    isHeroMode: boolean;
+    isHeroMode?: boolean;
   };
   serverDateTime: string;
 };


### PR DESCRIPTION
## 구현 내용
- 본인 프로필, 히어로 프로필, 시민 프로필 의 데이터를 업데이트합니다.
- UserResponse의 일부 타입은 null로 올 수 있어서 변경했습니다. 

## 스크린샷

## 궁금한 점

## 이슈번호
- closes #179 
