### PR TITLE
미션 검색 페이지 리팩토링

### DIFF
--- a/one-day-hero/src/app/search/mission/page.tsx
+++ b/one-day-hero/src/app/search/mission/page.tsx
@@ -39,7 +39,7 @@ const MissionSearchPage = () => {
 
   const { mutationalFetch } = useGetRegionsFetch(token ?? "");
 
-  const queryString = Number(useSearchParams().get("category"));
+  const queryString = Number(useSearchParams().get("category")) ?? 0;
   const router = useRouter();
 
   useEffect(() => {
@@ -98,6 +98,7 @@ const MissionSearchPage = () => {
     const gu = guRef.current?.value;
 
     setSelectedGu(gu);
+    setSelectedDong("선택");
   };
 
   const handleDongSelect = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -164,7 +165,11 @@ w-full max-w-screen-sm">
         </div>
 
         <div className="border-background-darken mt-3 flex justify-center border-b pb-2">
-          <Category onSelect={handleCategorySelect} size="sm" />
+          <Category
+            value={queryString}
+            onSelect={handleCategorySelect}
+            size="sm"
+          />
         </div>
       </section>
 

--- a/one-day-hero/src/components/common/Category.tsx
+++ b/one-day-hero/src/components/common/Category.tsx
@@ -28,7 +28,7 @@ export const CATEGORY_LIST = [
 ];
 
 type CategoryProps = {
-  value?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  value?: number;
   routeState?: boolean;
   error?: string;
   // eslint-disable-next-line no-unused-vars

--- a/one-day-hero/src/components/common/Info/MissionListItem.tsx
+++ b/one-day-hero/src/components/common/Info/MissionListItem.tsx
@@ -28,7 +28,7 @@ const MissionListItem = ({
   return (
     <div className={`flex w-full ${className}`}>
       <div className="flex grow gap-4">
-        <div className="overflow-hidden rounded-[10px] bg-inactive">
+        <div className="bg-inactive overflow-hidden rounded-[10px]">
           <Image
             src={imageSrc || defaultProfileImage}
             alt="프로필 사진"
@@ -38,7 +38,7 @@ const MissionListItem = ({
           />
         </div>
         <div className="flex flex-col gap-1">
-          <Label size="sm" className="w-16">
+          <Label size="sm" className="w-[5.05rem]">
             {categories}
           </Label>
           <span className="text-md font-semibold">{title}</span>

--- a/one-day-hero/src/components/common/Label.tsx
+++ b/one-day-hero/src/components/common/Label.tsx
@@ -11,7 +11,7 @@ const Label = ({
   ...props
 }: PropsWithChildren<LabelProps>) => {
   const sizes = {
-    sm: "text-xs min-w-16 h-4 px-4 rounded-3xl",
+    sm: "text-xs min-w-16 h-4 px-2 rounded-3xl",
     md: "text-sm min-w-28 h-6 px-3 rounded-3xl",
     lg: "text-lg min-w-[4.5rem] h-8 px-4 rounded-[0.625rem] border border-1 border-background-darken"
   };


### PR DESCRIPTION
## 구현 내용
- 홈페이지에 카테고리를 선택했을 경우 검색페이지에 카테고리 클릭이 반영되지 않았던 문제를 해결했습니다. 
- 지역 정보를 한번 선택한 경우에 구와 동 정보가 필터에 고정 되어 있는데, 새롭게 구 를 선택하게 되어도 이전에 선택한 동의 텍스트가 남아있는 문제가 있었는데 해결했습니다. 
- 서버에서 받아오는 카테고리가 `배달·운전` 이 아닌 `배달,운전` 으로 오는 것 같더라구요. (개인적으로 첫번째꺼 처럼 왔으면 좋겠는데.. ) 그래서 텍스트가 밖으로 나가는 문제 해결했습니다. 

## 스크린샷

https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/99384699/868f9886-2b51-43a4-aade-4ac18c82969a

## 궁금한 점
여기 수평 스크롤은 무조건 되야 하는데... 안 되네요.. 그때 fixed 써서 그런다고 했는데 방법을 좀 더 생각해 볼게요.

## 이슈번호
- closes #211
