### PR TITLE
이미지 에러 메세지 버그 수정

### DIFF
--- a/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
-import { forwardRef, useCallback } from "react";
+import { forwardRef, useCallback, useEffect } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 import Button from "@/components/common/Button";
@@ -28,10 +28,23 @@ const MandatorySurvey = forwardRef((userData: UserResponse, ref) => {
     handleSubmit,
     formState: { errors },
     setValue,
-    getValues
+    getValues,
+    clearErrors,
+    setError,
+    watch
   } = useForm<MandatorySurveySchemaProps>({
     resolver: zodResolver(MandatorySurveySchema)
   });
+
+  const imageWatch = watch("image");
+
+  useEffect(() => {
+    if (!errors.image) {
+      clearErrors("image");
+    } else {
+      return;
+    }
+  }, [imageWatch]);
 
   const sortedFavoriteRegions = favoriteRegions?.map((item) => item.id) ?? [0];
   const vaildatedFavoriteWorkingDay = favoriteWorkingDay ?? {
@@ -82,6 +95,7 @@ const MandatorySurvey = forwardRef((userData: UserResponse, ref) => {
   const handleFileSelect = useCallback(
     (file: ImageFileType[]) => {
       setValue("image", file);
+      clearErrors("image");
     },
     [setValue]
   );
@@ -101,7 +115,7 @@ const MandatorySurvey = forwardRef((userData: UserResponse, ref) => {
             onFileSelect={handleFileSelect}
           />
           {errors.image && (
-            <p className="text-red-500">{`${errors.image.message}`}</p>
+            <p className="text-red-500">프로필 이미지를 업로드 해주세요.</p>
           )}
         </div>
 

--- a/one-day-hero/src/components/domain/survey/OptionalSurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/OptionalSurvey.tsx
@@ -42,8 +42,6 @@ const OptionalSurvey = (userData: UserResponse) => {
 
   const { basicInfo } = userData.data;
 
-  console.log("베이직", basicInfo);
-
   const { mutationalFetch: getRegionsMutationalFetch } = useGetRegionsFetch(
     token ?? ""
   );
@@ -60,7 +58,6 @@ const OptionalSurvey = (userData: UserResponse) => {
 
         if (response) {
           const { gu } = response.data[0];
-          console.log("gu", gu);
 
           setGuData(gu);
         } else if (isError) {

--- a/one-day-hero/src/types/schema.ts
+++ b/one-day-hero/src/types/schema.ts
@@ -1,17 +1,12 @@
 import { z } from "zod";
 
 export const MandatorySurveySchema = z.object({
-  image: z
-    .array(
-      z.object({
-        file: z.any(),
-        id: z.string()
-      })
-    )
-    .refine((image) => image.length > 0, {
-      message: "이미지를 선택해 주세요.",
-      path: ["image"]
-    }),
+  image: z.array(
+    z.object({
+      file: z.any(),
+      id: z.string()
+    })
+  ),
   nickName: z
     .string()
     .refine(


### PR DESCRIPTION
## 구현 내용
이미지 미 첨부 시 설정한 에러메세지가 나오지 않았던 버그 수정했습니다. 
> 일단 react-hook-form 에서 제공해 주는 메서드를 사용해서 해결했는데 왜 스키마에 이미지 에러메세지를 설정했는데 출력이 안되는지 모르겠네요. 조건을 잘 못 단 거 같기도 하고...
> 일단은 스키마 안되는 부분은 뺐고 나중에 리팩토링 해보겠습니다. 

## 스크린샷
https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/99384699/ea03ead6-2a50-4f4a-8a9e-895bb40eed44

## 궁금한 점

## 이슈번호
- closes #214 
