### PR TITLE
리뷰 수정 중 이미지 삭제 api 연결

### DIFF
--- a/one-day-hero/src/components/domain/review/ReviewForm.tsx
+++ b/one-day-hero/src/components/domain/review/ReviewForm.tsx
@@ -12,6 +12,7 @@ import Textarea from "@/components/common/Textarea";
 import UploadImage from "@/components/common/UploadImage";
 import { useToast } from "@/contexts/ToastProvider";
 import { useUserId } from "@/contexts/UserIdProvider";
+import { useDeleteReviewImageFetch } from "@/services/review";
 import { ImageFileType } from "@/types";
 import { ReviewDetailResponse } from "@/types/response";
 import { ReviewFormSchema } from "@/types/schema";
@@ -56,6 +57,8 @@ const ReviewForm = ({
 
   const { showToast } = useToast();
   const router = useRouter();
+
+  const { mutationalFetch: deleteImageFetch } = useDeleteReviewImageFetch();
 
   const handleScoreSelect = (count: number) => {
     setScore(count);
@@ -174,6 +177,7 @@ const ReviewForm = ({
         <UploadImage
           onFileSelect={handleFileSelect}
           defaultImages={editDefaultData?.imageDatas}
+          deleteImageFetch={deleteImageFetch}
         />
       </div>
       <Button type="submit" className="cs:mt-3">

--- a/one-day-hero/src/services/review.ts
+++ b/one-day-hero/src/services/review.ts
@@ -5,7 +5,7 @@ import { useInfiniteFetch } from "@/hooks/useInfiniteFetch";
 
 import {
   CreateReviewResponse,
-  ReviewDeleteResponse,
+  EmptyResponse,
   ReviewDetailResponse,
   ReviewListResponse
 } from "./../types/response";
@@ -56,7 +56,7 @@ export const useGetSendReviewFetch = (
 };
 
 export const useDeleteSendReviewFetch = (reviewId: number) => {
-  return useMutationalFetch<ReviewDeleteResponse>(
+  return useMutationalFetch<EmptyResponse>(
     `/reviews/${reviewId}`,
     {
       method: "DELETE",
@@ -83,4 +83,15 @@ export const useGetReceiveReviewFetch = (
     },
     observerRef
   });
+};
+
+export const useDeleteReviewImageFetch = () => {
+  return useMutationalFetch<EmptyResponse>() as {
+    mutationalFetch: (
+      pathname: string,
+      fetchOptions: RequestInit,
+      onSuccess?: (response?: Response) => void,
+      onError?: () => void
+    ) => Promise<CustomResponse<EmptyResponse>>;
+  };
 };

--- a/one-day-hero/src/types/response.ts
+++ b/one-day-hero/src/types/response.ts
@@ -483,7 +483,7 @@ export type HeroNicknameResponse = {
   heroScore: 30;
 }[];
 
-export type ReviewDeleteResponse = {
+export type EmptyResponse = {
   status: number;
   data: null;
   serverDateTime: string;


### PR DESCRIPTION
## 구현 내용
- 리뷰 수정 중에 기존 이미지를 가져오고 삭제하는 기능을 구현했습니다.
- UploadImage 컴포넌트에 해당 부분을 구현했고 이전 방식으로도 동작하도록 구현했습니다.
- 이미지 개수 제한도 기존 이미지 개수를 합쳐서 계산합니다.

## 스크린샷

## 궁금한 점

## 이슈번호
- closes #233 
