### PR TITLE
필수 조사 페이지 닉네임, 자기소개 프로필 기본 값 처리

### DIFF
--- a/one-day-hero/src/app/notification/page.tsx
+++ b/one-day-hero/src/app/notification/page.tsx
@@ -1,5 +1,3 @@
-import NotificationItem from "@/components/domain/notification/NotificationItem";
-
 const NotificationPage = () => {
   return (
     <>

--- a/one-day-hero/src/components/common/DayList.tsx
+++ b/one-day-hero/src/components/common/DayList.tsx
@@ -10,6 +10,7 @@ import ToggleButton from "./ToggleButton";
 type DayListProps = {
   getValues: UseFormGetValues<FieldValues>;
   setValue: UseFormSetValue<FieldValues>;
+  watch: string[] | undefined;
   className?: "";
 };
 
@@ -40,9 +41,9 @@ const DayList = forwardRef(
             setValue={setValue}
             getValues={getValues}
             key={dayEN}
-            selectedDate={dayEN}>
-            {dayKR}
-          </ToggleButton>
+            dateName={dayEN}
+            dayKR={dayKR}
+          />
         ))}
       </div>
     );

--- a/one-day-hero/src/components/common/Select.tsx
+++ b/one-day-hero/src/components/common/Select.tsx
@@ -9,6 +9,7 @@ import ErrorMessage from "./ErrorMessage";
 interface SelectProps extends React.ComponentProps<"select"> {
   className?: string;
   error?: string;
+  value?: string;
 }
 
 const Select = forwardRef(
@@ -18,6 +19,7 @@ const Select = forwardRef(
       className,
       children,
       error,
+      value,
       ...props
     }: PropsWithChildren<SelectProps>,
     ref: ForwardedRef<HTMLSelectElement>
@@ -37,7 +39,7 @@ const Select = forwardRef(
             error && "border-2 border-red-500"
           }`}
           {...props}>
-          <option value="">선택</option>
+          <option>{value ?? "선택"}</option>
           {children}
         </select>
         {error && <ErrorMessage>{error}</ErrorMessage>}

--- a/one-day-hero/src/components/common/ToggleButton.tsx
+++ b/one-day-hero/src/components/common/ToggleButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PropsWithChildren, useCallback, useState } from "react";
+import { PropsWithChildren, useCallback, useEffect, useState } from "react";
 import {
   FieldValues,
   UseFormGetValues,
@@ -9,28 +9,39 @@ import {
 
 type ToggleButtonProps = {
   className?: "";
-  selectedDate: string;
+  dateName: string;
   setValue: UseFormSetValue<FieldValues>;
   getValues: UseFormGetValues<FieldValues>;
+  dayKR: string;
 };
 
 const ToggleButton = ({
-  children,
   className,
   setValue,
   getValues,
-  selectedDate,
+  dayKR,
+  dateName,
   ...props
 }: PropsWithChildren<ToggleButtonProps>) => {
   const [clicked, setClicked] = useState<boolean>(false);
+
+  const checked = getValues("favoriteWorkingDay.favoriteDate")?.includes(
+    dateName
+  );
+
+  useEffect(() => {
+    if (checked) {
+      setClicked(!clicked);
+    }
+  }, []);
 
   const handleButtonClick = useCallback(() => {
     const setArray = () => {
       const prevArray = getValues("favoriteWorkingDay.favoriteDate") || [];
 
-      const updatedArray = prevArray.includes(selectedDate)
-        ? prevArray.filter((day: string) => day !== selectedDate)
-        : [...prevArray, selectedDate];
+      const updatedArray = prevArray.includes(dateName)
+        ? prevArray.filter((day: string) => day !== dateName)
+        : [...prevArray, dateName];
 
       return updatedArray;
     };
@@ -38,24 +49,22 @@ const ToggleButton = ({
     const test = setArray();
 
     setValue("favoriteWorkingDay.favoriteDate", test);
-
-    setClicked(!clicked);
-  }, [setValue, clicked, getValues, selectedDate]);
+  }, [setValue, getValues, dateName]);
 
   const defaultStyle = "w-11 h-11 text-base text-black rounded-lg border";
 
   return (
-    <button
+    <input
+      value={dayKR}
       type="button"
       className={`${defaultStyle} ${
-        clicked
-          ? "border-4 border-primary bg-primary-lightest"
+        checked
+          ? "border-primary bg-primary-lightest border-4"
           : "border-background-darken bg-white"
       } ${className}`}
       onClick={handleButtonClick}
-      {...props}>
-      {children}
-    </button>
+      {...props}
+    />
   );
 };
 

--- a/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
@@ -124,6 +124,7 @@ const MandatorySurvey = forwardRef((userData: UserResponse, ref) => {
             닉네임
           </InputLabel>
           <input
+            defaultValue={basicInfo.nickname}
             {...register("nickName")}
             className="border-inactive placeholder:text-inactive focus:outline-primary h-11 w-full rounded-[10px] border p-4 pl-3"
           />
@@ -137,6 +138,7 @@ const MandatorySurvey = forwardRef((userData: UserResponse, ref) => {
             자기소개
           </InputLabel>
           <textarea
+            defaultValue={basicInfo.introduce}
             {...register("introduction")}
             className="border-inactive focus:outline-primary h-40 w-full max-w-screen-sm resize-none rounded-2xl border p-4"
           />

--- a/one-day-hero/src/types/response.ts
+++ b/one-day-hero/src/types/response.ts
@@ -647,6 +647,39 @@ export type NotificationResponse = {
   serverDateTime: string;
 };
 
+export type ProfileResponse = {
+  status: number;
+  data: {
+    basicInfo: {
+      nickname: string;
+      gender: string;
+      birth: string;
+      introduce: string;
+    };
+    image: {
+      originalName: string | null;
+      uniqueName: string | null;
+      path: string | null;
+    };
+    favoriteWorkingDay: {
+      favoriteDate: string[] | undefined;
+      favoriteStartTime: string | undefined;
+      favoriteEndTime: string | undefined;
+    };
+    favoriteRegions:
+      | {
+          id: number;
+          si: string;
+          gu: string;
+          dong: string;
+        }[]
+      | undefined;
+    heroScore: number;
+    isHeroMode?: boolean;
+  };
+  serverDateTime: string;
+};
+
 export type MapResponse = {
   status: number;
   data: {


### PR DESCRIPTION
## 구현 내용
필수 조사 페이지 사진을 제외하고 기존 프로필의 닉네임과 자기소개를 불러 올 수 있도록 수정했습니다.  
> mandatory survey 부분만 봐주시면 됩니다. 

## 스크린샷
https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/99384699/65764be2-115e-4a80-92fb-f37432c2967f

## 궁금한 점
프로필 페이지 이미지가 기본 이미지로 고정 되어 있는 듯 합니다. 

## 이슈번호
- closes #237
