### PR TITLE
알림 이슈 처리

### DIFF
--- a/one-day-hero/src/app/layout.tsx
+++ b/one-day-hero/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { Noto_Sans_KR } from "next/font/google";
 
 import Toast from "@/components/common/Toast";
+import NotificationProvider from "@/contexts/NotificationProvider";
 import ToastProvider from "@/contexts/ToastProvider";
 import UserIdProvider from "@/contexts/UserIdProvider";
 
@@ -27,9 +28,11 @@ export default function RootLayout({
       <body className={`${notoSansKR.className} flex flex-col items-center`}>
         <UserIdProvider>
           <ToastProvider>
-            <main className="flex min-h-screen w-full max-w-screen-sm flex-col items-center bg-background px-5 py-24 shadow">
-              {children}
-            </main>
+            <NotificationProvider>
+              <main className="bg-background flex min-h-screen w-full max-w-screen-sm flex-col items-center px-5 py-24 shadow">
+                {children}
+              </main>
+            </NotificationProvider>
             <Toast />
           </ToastProvider>
         </UserIdProvider>

--- a/one-day-hero/src/app/notification/page.tsx
+++ b/one-day-hero/src/app/notification/page.tsx
@@ -4,7 +4,7 @@ const NotificationPage = () => {
   return (
     <>
       <div className="flex w-full flex-col items-center">
-        {/* <NotificationItem /> */}
+        <NotificationItem />
       </div>
     </>
   );

--- a/one-day-hero/src/app/utils/storage.ts
+++ b/one-day-hero/src/app/utils/storage.ts
@@ -1,0 +1,27 @@
+export const getLocalStorage = (key: string, defaultValue = false) => {
+  try {
+    const value = localStorage.getItem(key);
+
+    return value ? JSON.parse(value) : defaultValue;
+  } catch (error) {
+    console.log(error);
+
+    return defaultValue;
+  }
+};
+
+export const setLocalStorage = (key: string, value: boolean) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export const deleteLocalStorage = (key: string) => {
+  try {
+    localStorage.removeItem(key);
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/one-day-hero/src/components/common/NotificationCircle.tsx
+++ b/one-day-hero/src/components/common/NotificationCircle.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useNotification } from "@/contexts/NotificationProvider";
+import { getLocalStorage } from "@/app/utils/storage";
 
 const NotificationCircle = () => {
-  const alarmStatus = useNotification();
+  const alarmStatus = getLocalStorage("sse");
 
   return (
     <>

--- a/one-day-hero/src/components/common/NotificationCircle.tsx
+++ b/one-day-hero/src/components/common/NotificationCircle.tsx
@@ -1,13 +1,15 @@
 "use client";
 
+import { useNotification } from "@/contexts/NotificationProvider";
+
 const NotificationCircle = () => {
-  // const { alarmStatus } = useNotification();
+  const alarmStatus = useNotification();
 
   return (
     <>
-      {/* {alarmStatus ? (
+      {alarmStatus ? (
         <div className="bg-active absolute right-0 top-0 h-2.5 w-2.5 animate-ping rounded-full" />
-      ) : null} */}
+      ) : null}
     </>
   );
 };

--- a/one-day-hero/src/components/domain/notification/NotificationItem.tsx
+++ b/one-day-hero/src/components/domain/notification/NotificationItem.tsx
@@ -5,22 +5,18 @@ import { BsFillCircleFill } from "react-icons/bs";
 
 import { getClientToken } from "@/app/utils/cookie";
 import { formatDate } from "@/app/utils/formatDate";
+import { setLocalStorage } from "@/app/utils/storage";
 import Container from "@/components/common/Container";
-import { useNotification } from "@/contexts/NotificationProvider";
 import { useGetNotificationFetch } from "@/services/notification";
 
 const NotificationItem = () => {
   const observerRef = useRef<HTMLDivElement | null>(null);
 
-  const { setAlarmStatus } = useNotification();
-
-  setAlarmStatus(false);
+  setLocalStorage("sse", false);
 
   const token = getClientToken();
 
   const { data } = useGetNotificationFetch(token ?? "", observerRef);
-
-  console.log(data);
 
   return (
     <>

--- a/one-day-hero/src/contexts/NotificationProvider.tsx
+++ b/one-day-hero/src/contexts/NotificationProvider.tsx
@@ -6,12 +6,14 @@ import {
   Dispatch,
   SetStateAction,
   useContext,
-  useEffect,
-  useState
+  useEffect
 } from "react";
 
 import { getClientToken } from "@/app/utils/cookie";
+import { getLocalStorage, setLocalStorage } from "@/app/utils/storage";
 import { apiUrl } from "@/services/base";
+
+import { useToast } from "./ToastProvider";
 
 type NotificationContextType = {
   alarmStatus: boolean;
@@ -21,7 +23,7 @@ type NotificationContextType = {
 const NotificationContext = createContext<NotificationContextType | null>(null);
 
 const NotificationProvider = ({ children }: { children: React.ReactNode }) => {
-  const [alarmStatus, setAlarmStatus] = useState<boolean>(false);
+  const { showToast } = useToast();
 
   useEffect(() => {
     const token = getClientToken();
@@ -33,29 +35,28 @@ const NotificationProvider = ({ children }: { children: React.ReactNode }) => {
         }
       });
 
-      eventSource.onmessage = async (event) => {
+      eventSource.onmessage = (event) => {
         const res = event.data;
-        console.log(res);
 
-        setAlarmStatus(true);
-      };
+        if (res === "sse") {
+          return;
+        }
 
-      eventSource.onerror = (e) => {
-        setAlarmStatus(false);
-        throw new Error("알림 구독에서 에러가 발생했습니다.");
+        showToast("새로운 알림이 도착했어요!", "success");
+
+        setLocalStorage("sse", true);
       };
 
       return () => {
         if (eventSource) {
-          setAlarmStatus(false);
           eventSource.close();
         }
       };
     }
-  }, []);
+  }, [showToast]);
 
   return (
-    <NotificationContext.Provider value={{ alarmStatus, setAlarmStatus }}>
+    <NotificationContext.Provider value={getLocalStorage("sse")}>
       {children}
     </NotificationContext.Provider>
   );


### PR DESCRIPTION
## 구현 내용
알림이 오면 toast로 새로운 알림이 왔음을 전역적으로 어디서든 알려주고 로컬스토리지에 상태를 저장해서 홈페이지에 알림이 있다면 빨간색 동그라미가 생기고 알림 페이지로 이동 시 읽음처리 되어 다시 홈으로 이동하면 사라집니다!

## 스크린샷

## 궁금한 점
이상하게 context의 value를 사용하려고 하면 똑같은 스토리지의 값인데도 바로 홈페이지에 반영되지 않는 오류가 있어 Notification Circle 에서도 스토리지 값을 따로 받아와서 처리하고 있습니다. 괜찮을까요?

## 이슈번호
- closes #242 
