### PR TITLE
캐시 처리 및 핫 픽스 2

### DIFF
--- a/one-day-hero/src/app/api/createMandatorySurvey/route.ts
+++ b/one-day-hero/src/app/api/createMandatorySurvey/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
 import { getServerToken } from "@/app/utils/auth";
@@ -26,9 +27,11 @@ export async function POST(request: NextRequest) {
   if (isError || !response) {
     console.log(errorMessage);
     return new NextResponse(null, {
-      status: 400
+      status: response?.status ?? 400
     });
   }
+
+  revalidateTag("user");
 
   return NextResponse.json(
     {

--- a/one-day-hero/src/app/api/createMandatorySurvey/route.ts
+++ b/one-day-hero/src/app/api/createMandatorySurvey/route.ts
@@ -26,8 +26,8 @@ export async function POST(request: NextRequest) {
 
   if (isError || !response) {
     console.log(errorMessage);
-    return new NextResponse(null, {
-      status: response?.status ?? 400
+    return NextResponse.json(response ?? {}, {
+      status: 400
     });
   }
 

--- a/one-day-hero/src/app/api/createOptionalSurvey/route.ts
+++ b/one-day-hero/src/app/api/createOptionalSurvey/route.ts
@@ -24,8 +24,8 @@ export async function POST(request: NextRequest) {
   if (isError || !response) {
     console.log(errorMessage);
 
-    return new NextResponse(null, {
-      status: response?.status ?? 400
+    return NextResponse.json(response ?? {}, {
+      status: 400
     });
   }
 

--- a/one-day-hero/src/app/api/createOptionalSurvey/route.ts
+++ b/one-day-hero/src/app/api/createOptionalSurvey/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
 import { getServerToken } from "@/app/utils/auth";
@@ -24,9 +25,11 @@ export async function POST(request: NextRequest) {
     console.log(errorMessage);
 
     return new NextResponse(null, {
-      status: 400
+      status: response?.status ?? 400
     });
   }
+
+  revalidateTag("user");
 
   return NextResponse.json(
     {

--- a/one-day-hero/src/app/api/createPost/route.ts
+++ b/one-day-hero/src/app/api/createPost/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
 import { getServerToken } from "@/app/utils/auth";
@@ -25,9 +26,12 @@ export async function POST(request: NextRequest) {
   if (isError || !postResponse) {
     console.log(errorMessage);
     return new NextResponse(null, {
-      status: 400
+      status: postResponse?.status ?? 400
     });
   }
+
+  revalidateTag("progress");
+  revalidateTag("matching");
 
   return NextResponse.json(
     {

--- a/one-day-hero/src/app/api/createPost/route.ts
+++ b/one-day-hero/src/app/api/createPost/route.ts
@@ -25,8 +25,8 @@ export async function POST(request: NextRequest) {
 
   if (isError || !postResponse) {
     console.log(errorMessage);
-    return new NextResponse(null, {
-      status: postResponse?.status ?? 400
+    return NextResponse.json(postResponse ?? {}, {
+      status: 400
     });
   }
 

--- a/one-day-hero/src/app/api/createReview/route.ts
+++ b/one-day-hero/src/app/api/createReview/route.ts
@@ -25,8 +25,8 @@ export async function POST(request: NextRequest) {
 
   if (isError || !postResponse) {
     console.log(errorMessage);
-    return new NextResponse(null, {
-      status: postResponse?.status ?? 400
+    return NextResponse.json(postResponse ?? {}, {
+      status: 400
     });
   }
 

--- a/one-day-hero/src/app/api/createReview/route.ts
+++ b/one-day-hero/src/app/api/createReview/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
 import { getServerToken } from "@/app/utils/auth";
@@ -25,9 +26,11 @@ export async function POST(request: NextRequest) {
   if (isError || !postResponse) {
     console.log(errorMessage);
     return new NextResponse(null, {
-      status: 400
+      status: postResponse?.status ?? 400
     });
   }
+
+  revalidateTag("reviews");
 
   return NextResponse.json(
     {

--- a/one-day-hero/src/app/api/editReview/[slug]/route.ts
+++ b/one-day-hero/src/app/api/editReview/[slug]/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
 import { getServerToken } from "@/app/utils/auth";
@@ -28,9 +29,11 @@ export async function POST(
   if (isError || !postResponse) {
     console.log(errorMessage);
     return new NextResponse(null, {
-      status: 400
+      status: postResponse?.status ?? 400
     });
   }
+
+  revalidateTag(`review${params.slug}`);
 
   return NextResponse.json(
     {

--- a/one-day-hero/src/app/api/editReview/[slug]/route.ts
+++ b/one-day-hero/src/app/api/editReview/[slug]/route.ts
@@ -28,8 +28,8 @@ export async function POST(
 
   if (isError || !postResponse) {
     console.log(errorMessage);
-    return new NextResponse(null, {
-      status: postResponse?.status ?? 400
+    return NextResponse.json(postResponse ?? {}, {
+      status: 400
     });
   }
 

--- a/one-day-hero/src/app/api/revalidateTag/route.ts
+++ b/one-day-hero/src/app/api/revalidateTag/route.ts
@@ -1,0 +1,20 @@
+import { revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  const data = await request.json();
+
+  (data.tag as string[]).forEach((tagItem) => {
+    revalidateTag(tagItem);
+  });
+
+  return NextResponse.json(
+    {
+      status: 200,
+      data: {
+        tag: data.tag
+      }
+    },
+    { status: 200 }
+  );
+}

--- a/one-day-hero/src/app/api/token/route.ts
+++ b/one-day-hero/src/app/api/token/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
   if (isError || !tokenResponse) {
     console.log(errorMessage);
     return new NextResponse(null, {
-      status: 400
+      status: tokenResponse?.status ?? 400
     });
   }
 

--- a/one-day-hero/src/app/chatting/[slug]/layout.tsx
+++ b/one-day-hero/src/app/chatting/[slug]/layout.tsx
@@ -39,7 +39,8 @@ const ChattingLayout = async ({ params, children }: LayoutProps) => {
     description: "매칭을 취소합니다.",
     apiPath: "/mission-matches/cancel",
     method: "PUT",
-    requiredData: [{ name: "missionId", default: thisRoomData?.missionId }]
+    requiredData: [{ name: "missionId", default: thisRoomData?.missionId }],
+    refresh: true
   };
 
   return (

--- a/one-day-hero/src/app/chatting/[slug]/page.tsx
+++ b/one-day-hero/src/app/chatting/[slug]/page.tsx
@@ -52,10 +52,10 @@ const ChattingPage = async ({ params }: { params: { slug: string } }) => {
         receiverId={thisRoomData.receiverId}
         receiverImagePath={thisRoomData.receiverImagePath}>
         {chatRecordResponse.data.map(
-          ({ message, senderNickName, sentMessageTime, senderId }, index) => {
+          ({ message, senderNickName, sentMessageTime, senderId }) => {
             return (
               <Message
-                key={index}
+                key={`${senderId}_${sentMessageTime}`}
                 imagePath={thisRoomData.receiverImagePath}
                 message={message}
                 ninkName={senderNickName}

--- a/one-day-hero/src/app/citizenProfile/[slug]/page.tsx
+++ b/one-day-hero/src/app/citizenProfile/[slug]/page.tsx
@@ -1,12 +1,11 @@
-import Image from "next/image";
 import { redirect } from "next/navigation";
 
-import DefaultThumbnail from "/public/images/OneDayHero_logo_sm.svg";
 import ErrorPage from "@/app/error";
 import { getServerToken } from "@/app/utils/auth";
 import { calculateAge, parseGender } from "@/app/utils/formatProfile";
 import HeroScore from "@/components/common/HeroScore";
 import LinkButton from "@/components/common/LinkButton";
+import ProfileImage from "@/components/common/ProfileImage";
 import HelpCircle from "@/components/domain/profile/HelpCircle";
 import { HELP_MESSAGES } from "@/constants/helpMessage";
 import { useGetProfileFetch } from "@/services/users";
@@ -26,17 +25,16 @@ const CitizenProfilePage = async ({ params }: { params: { slug: string } }) => {
   if (isError || !response) return <ErrorPage />;
 
   const {
-    data: { basicInfo, heroScore }
+    data: { basicInfo, heroScore, image }
   } = response;
 
   return (
     <>
       <div className="flex w-full">
-        <Image
-          src={DefaultThumbnail}
-          alt="썸네일"
+        <ProfileImage
+          src={image.path || ""}
+          alt="프로필 이미지"
           width={150}
-          className="pointer-events-none mr-3 rounded-full bg-neutral-200"
           priority
         />
         <div className="flex grow flex-col justify-evenly text-base">

--- a/one-day-hero/src/app/heroProfile/[slug]/page.tsx
+++ b/one-day-hero/src/app/heroProfile/[slug]/page.tsx
@@ -1,12 +1,11 @@
-import Image from "next/image";
 import { redirect } from "next/navigation";
 
-import DefaultThumbnail from "/public/images/OneDayHero_logo_sm.svg";
 import ErrorPage from "@/app/error";
 import { getServerToken } from "@/app/utils/auth";
 import { calculateAge, parseGender } from "@/app/utils/formatProfile";
 import HeroScore from "@/components/common/HeroScore";
 import LinkButton from "@/components/common/LinkButton";
+import ProfileImage from "@/components/common/ProfileImage";
 import FavoriteDateList from "@/components/domain/profile/FavoriteDateList";
 import HelpCircle from "@/components/domain/profile/HelpCircle";
 import { HELP_MESSAGES } from "@/constants/helpMessage";
@@ -29,11 +28,10 @@ const HeroProfilePage = async ({ params }: { params: { slug: string } }) => {
   return (
     <>
       <div className="flex w-full">
-        <Image
-          src={image?.path || DefaultThumbnail}
-          alt="썸네일"
+        <ProfileImage
+          src={image.path || ""}
+          alt="프로필 이미지"
           width={150}
-          className="pointer-events-none mr-3 rounded-full bg-neutral-200"
           priority
         />
         <div className="flex grow flex-col justify-evenly text-base">
@@ -83,11 +81,6 @@ const HeroProfilePage = async ({ params }: { params: { slug: string } }) => {
       <div className="mb-12 w-full">
         <h2 className="mb-2 mt-5 text-xl font-semibold">소개</h2>
         <div className="rounded-lg border border-background-darken bg-white p-2">
-          {/* <div className="mb-2 flex gap-2">
-            <Label size="lg">카페</Label>
-            <Label size="lg">식당</Label>
-            <Label size="lg">청소</Label>
-          </div> */}
           <p>{basicInfo.introduce}</p>
         </div>
       </div>
@@ -96,9 +89,6 @@ const HeroProfilePage = async ({ params }: { params: { slug: string } }) => {
         className="cs:mb-3 cs:w-full">
         리뷰
       </LinkButton>
-      {/* <LinkButton href="/mission/record" className="cs:mb-3 cs:w-full">
-        미션 기록
-      </LinkButton> */}
     </>
   );
 };

--- a/one-day-hero/src/app/profile/page.tsx
+++ b/one-day-hero/src/app/profile/page.tsx
@@ -1,12 +1,10 @@
-import Image from "next/image";
 import { redirect } from "next/navigation";
 
-import DefaultThumbnail from "/public/images/OneDayHero_logo_sm.svg";
 import ErrorPage from "@/app/error";
 import { calculateAge, parseGender } from "@/app/utils/formatProfile";
 import HeroScore from "@/components/common/HeroScore";
-import Label from "@/components/common/Label";
 import LinkButton from "@/components/common/LinkButton";
+import ProfileImage from "@/components/common/ProfileImage";
 import FavoriteDateList from "@/components/domain/profile/FavoriteDateList";
 import HelpCircle from "@/components/domain/profile/HelpCircle";
 import HeroSwitch from "@/components/domain/profile/HeroSwitch";
@@ -40,11 +38,10 @@ const ProfilePage = async () => {
   return (
     <>
       <div className="flex w-full">
-        <Image
-          src={image.path || DefaultThumbnail}
-          alt="썸네일"
+        <ProfileImage
+          src={image.path || ""}
+          alt="프로필 이미지"
           width={150}
-          className="pointer-events-none mr-3 rounded-full bg-neutral-200"
           priority
         />
         <div className="flex grow flex-col justify-evenly text-base">
@@ -109,11 +106,6 @@ const ProfilePage = async () => {
       <div className="mb-12 w-full">
         <h2 className="mb-2 mt-5 text-xl font-semibold">소개</h2>
         <div className="rounded-lg border border-background-darken bg-white p-2">
-          {/* <div className="mb-2 flex gap-2">
-            <Label size="lg">카페</Label>
-            <Label size="lg">식당</Label>
-            <Label size="lg">청소</Label>
-          </div> */}
           <p>{basicInfo.introduce}</p>
         </div>
       </div>

--- a/one-day-hero/src/app/search/mission/page.tsx
+++ b/one-day-hero/src/app/search/mission/page.tsx
@@ -45,7 +45,7 @@ const MissionSearchPage = () => {
   useEffect(() => {
     handleCategorySelect(queryString);
 
-    router.push("/search/mission");
+    router.replace("/search/mission");
   }, []);
 
   useEffect(() => {

--- a/one-day-hero/src/components/common/KebabMenu/KebabModal.tsx
+++ b/one-day-hero/src/components/common/KebabMenu/KebabModal.tsx
@@ -17,7 +17,15 @@ type KebabModalProps = {
 };
 
 const KebabModal = ({ isOpen, onClose, menuData }: KebabModalProps) => {
-  const { apiPath, method, name, requiredData, description, redirectTo } =
+  const {
+    apiPath,
+    method,
+    name,
+    requiredData,
+    description,
+    redirectTo,
+    refresh
+  } =
     menuData || ({ apiPath: "", method: "GET", name: "" } as KebabMenuDataType);
 
   const token = getClientToken();
@@ -31,7 +39,7 @@ const KebabModal = ({ isOpen, onClose, menuData }: KebabModalProps) => {
     method: method,
     headers: {
       Authorization: `Bearer ${token}`,
-      "Content-Type": "application-json"
+      "Content-Type": "application/json"
     },
     body: requestBody ? JSON.stringify(requestBody) : undefined
   });
@@ -48,6 +56,8 @@ const KebabModal = ({ isOpen, onClose, menuData }: KebabModalProps) => {
     }
 
     showToast(`${name}에 성공했습니다.`, "success");
+
+    refresh && router.refresh();
     redirectTo && router.push(redirectTo);
   };
 

--- a/one-day-hero/src/components/common/Tabs.tsx
+++ b/one-day-hero/src/components/common/Tabs.tsx
@@ -29,14 +29,16 @@ const Tabs = ({ leftRoute, rightRoute, className = "" }: TabsProps) => {
           className={`${tabDefaultStyle} ${
             pathName === leftRoute.path ? "bg-primary " : ""
           }`}
-          href={leftRoute.path}>
+          href={leftRoute.path}
+          replace>
           {leftRoute.name}
         </Link>
         <Link
           className={`${tabDefaultStyle} ${
             pathName === rightRoute.path ? "bg-primary" : ""
           }`}
-          href={rightRoute.path}>
+          href={rightRoute.path}
+          replace>
           {rightRoute.name}
         </Link>
       </div>

--- a/one-day-hero/src/components/domain/chatting/MissionProgressButtonBar.tsx
+++ b/one-day-hero/src/components/domain/chatting/MissionProgressButtonBar.tsx
@@ -100,7 +100,7 @@ const MissionProgressButtonBar = ({
   return (
     <>
       <div className={`${defaultStyle} ${className}`} {...props}>
-        <button className={` ${progressStyle["active"]} ${buttonDefaultStyle}`}>
+        <button className={`${progressStyle["active"]} ${buttonDefaultStyle}`}>
           매칭중
         </button>
         <span className="h-0 w-2/12 border border-black " />

--- a/one-day-hero/src/components/domain/chatting/MissionProgressButtonBar.tsx
+++ b/one-day-hero/src/components/domain/chatting/MissionProgressButtonBar.tsx
@@ -7,6 +7,7 @@ import Button from "@/components/common/Button";
 import Modal from "@/components/common/Modal";
 import { useToast } from "@/contexts/ToastProvider";
 import useModal from "@/hooks/useModal";
+import { passRevalidateTag } from "@/services/base";
 import { useCompleteMissionFetch, useCreateMatchFetch } from "@/services/chats";
 
 interface MissionProgressButtonBarProps extends React.ComponentProps<"div"> {
@@ -53,8 +54,12 @@ const MissionProgressButtonBar = ({
 
   const handleConfirm = async () => {
     const { isError } = await (missionStatus === "MATCHING"
-      ? createMatchFetch()
-      : completeMissionFetch());
+      ? createMatchFetch(() => {
+          passRevalidateTag(["progress", "matching"]);
+        })
+      : completeMissionFetch(() => {
+          passRevalidateTag(["progress", "matching"]);
+        }));
 
     if (isError) {
       showToast(

--- a/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
+++ b/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
@@ -116,7 +116,7 @@ const CreateForm = () => {
 
         const createdMissionId = (await response.json()).data.id;
 
-        router.push(`/mission/${createdMissionId}`);
+        router.replace(`/mission/${createdMissionId}`);
       } catch (err) {
         showToast("생성 중 오류가 발생했습니다. 다시 시도해주세요", "error");
       }

--- a/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
+++ b/one-day-hero/src/components/domain/mission/create/CreateForm.tsx
@@ -11,6 +11,7 @@ import InputLabel from "@/components/common/InputLabel";
 import Select from "@/components/common/Select";
 import Textarea from "@/components/common/Textarea";
 import UploadImage from "@/components/common/UploadImage";
+import { useToast } from "@/contexts/ToastProvider";
 import useFormValidation, { FormErrors } from "@/hooks/useFormValidation";
 import { ImageFileType, LocationType } from "@/types";
 import { MissionCreateRequest } from "@/types/request";
@@ -36,6 +37,7 @@ const CreateForm = () => {
   const { missionCreateValidation } = useFormValidation();
 
   const router = useRouter();
+  const { showToast } = useToast();
 
   const handleSelect = (id: number) => {
     setCategoryId(id);
@@ -93,17 +95,31 @@ const CreateForm = () => {
     setErrors(validationErrors);
 
     if (!Object.keys(validationErrors).length) {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_FE_URL}/api/createPost`,
-        {
-          method: "POST",
-          body: formData
+      try {
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_FE_URL}/api/createPost`,
+          {
+            method: "POST",
+            body: formData
+          }
+        );
+
+        if (!response.ok) {
+          const data = await response.json();
+
+          const errorCode = data?.code;
+          const errorMessage = data?.message;
+
+          showToast(errorMessage, "error");
+          return;
         }
-      );
 
-      const createdMissionId = (await response.json()).data.id;
+        const createdMissionId = (await response.json()).data.id;
 
-      router.push(`/mission/${createdMissionId}`);
+        router.push(`/mission/${createdMissionId}`);
+      } catch (err) {
+        showToast("생성 중 오류가 발생했습니다. 다시 시도해주세요", "error");
+      }
     }
   };
 
@@ -135,7 +151,7 @@ const CreateForm = () => {
         </div>
         <div>
           <InputLabel>
-            사진 <span className="text-inactive text-xs">(최대 3개)</span>
+            사진 <span className="text-xs text-inactive">(최대 3개)</span>
           </InputLabel>
           <UploadImage onFileSelect={handleFileSelect} />
         </div>

--- a/one-day-hero/src/components/domain/review/ReviewForm.tsx
+++ b/one-day-hero/src/components/domain/review/ReviewForm.tsx
@@ -120,7 +120,13 @@ const ReviewForm = ({
       );
 
       if (!response.ok) {
-        throw new Error(response.statusText);
+        const data = await response.json();
+
+        const errorCode = data?.code;
+        const errorMessage = data?.message;
+
+        showToast(errorMessage, "error");
+        return;
       }
 
       const reviewId = (await response.json()).data.id;

--- a/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/MandatorySurvey.tsx
@@ -8,6 +8,7 @@ import { SubmitHandler, useForm } from "react-hook-form";
 import Button from "@/components/common/Button";
 import InputLabel from "@/components/common/InputLabel";
 import UploadImage from "@/components/common/UploadImage";
+import { useToast } from "@/contexts/ToastProvider";
 import { ImageFileType } from "@/types";
 import {
   UserInfoForOptionalSurveyResponse,
@@ -22,6 +23,7 @@ const MandatorySurvey = forwardRef((userData: UserResponse, ref) => {
   const { basicInfo, favoriteRegions, favoriteWorkingDay } = userData.data;
 
   const router = useRouter();
+  const { showToast } = useToast();
 
   const {
     register,
@@ -84,12 +86,29 @@ const MandatorySurvey = forwardRef((userData: UserResponse, ref) => {
       formData.append("images", imageBlob, "image.jpeg");
     }
 
-    fetch(`${process.env.NEXT_PUBLIC_FE_URL}/api/createMandatorySurvey`, {
-      method: "POST",
-      body: formData
-    }).then(() => {
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_FE_URL}/api/createMandatorySurvey`,
+        {
+          method: "POST",
+          body: formData
+        }
+      );
+
+      if (!response.ok) {
+        const data = await response.json();
+
+        const errorCode = data?.code;
+        const errorMessage = data?.message;
+
+        showToast(errorMessage, "error");
+        return;
+      }
+
       router.push("/survey/optional");
-    });
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   const handleFileSelect = useCallback(
@@ -125,7 +144,7 @@ const MandatorySurvey = forwardRef((userData: UserResponse, ref) => {
           </InputLabel>
           <input
             {...register("nickName")}
-            className="border-inactive placeholder:text-inactive focus:outline-primary h-11 w-full rounded-[10px] border p-4 pl-3"
+            className="h-11 w-full rounded-[10px] border border-inactive p-4 pl-3 placeholder:text-inactive focus:outline-primary"
           />
           {errors.nickName && (
             <p className="text-red-500">{`${errors.nickName.message}`}</p>
@@ -138,7 +157,7 @@ const MandatorySurvey = forwardRef((userData: UserResponse, ref) => {
           </InputLabel>
           <textarea
             {...register("introduction")}
-            className="border-inactive focus:outline-primary h-40 w-full max-w-screen-sm resize-none rounded-2xl border p-4"
+            className="h-40 w-full max-w-screen-sm resize-none rounded-2xl border border-inactive p-4 focus:outline-primary"
           />
           {errors.introduction && (
             <p className="text-red-500">{`${errors.introduction.message}`}</p>

--- a/one-day-hero/src/components/domain/survey/OptionalSurvey.tsx
+++ b/one-day-hero/src/components/domain/survey/OptionalSurvey.tsx
@@ -139,7 +139,7 @@ const OptionalSurvey = (userData: UserResponse) => {
     setFavoriteDongId(Number(e.target.value));
   };
 
-  const onSubmit: SubmitHandler<OptionalSurveySchemaProps> = (
+  const onSubmit: SubmitHandler<OptionalSurveySchemaProps> = async (
     data: OptionalSurveySchemaProps
   ) => {
     const { favoriteWorkingDay, favoriteRegions } = data;
@@ -163,12 +163,29 @@ const OptionalSurvey = (userData: UserResponse) => {
       new Blob([jsonData], { type: "application/json" })
     );
 
-    fetch(`${process.env.NEXT_PUBLIC_FE_URL}/api/createOptionalSurvey`, {
-      method: "POST",
-      body: formData
-    }).then(() => {
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_FE_URL}/api/createOptionalSurvey`,
+        {
+          method: "POST",
+          body: formData
+        }
+      );
+
+      if (!response.ok) {
+        const data = await response.json();
+
+        const errorCode = data?.code;
+        const errorMessage = data?.message;
+
+        showToast(errorMessage, "error");
+        return;
+      }
+
       router.push("/");
-    });
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   return (

--- a/one-day-hero/src/services/base.ts
+++ b/one-day-hero/src/services/base.ts
@@ -79,3 +79,24 @@ export const useMutationalFetch = <T>(
     mutationalFetch: (useFetch<T>).bind(null, ...useFetchArguments)
   };
 };
+
+export const passRevalidateTag = async (tag: string[]) => {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_FE_URL}/api/revalidateTag`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          tag
+        }),
+        headers: { "Content-Type": "application/json" }
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(response.statusText);
+    }
+  } catch (err) {
+    console.error(err);
+  }
+};

--- a/one-day-hero/src/services/map.ts
+++ b/one-day-hero/src/services/map.ts
@@ -1,6 +1,5 @@
 import { MutableRefObject } from "react";
 
-import { getClientToken } from "@/app/utils/cookie";
 import { useInfiniteFetch } from "@/hooks/useInfiniteFetch";
 import { MapResponse } from "@/types/response";
 
@@ -10,11 +9,11 @@ export const useGetMapMissionList = (
 ) => {
   return useInfiniteFetch<MapResponse>({
     pathname: `/missions/around`,
-    size: 4,
+    size: 10,
     observerRef,
     options: {
       headers: { Authorization: `Bearer ${token}` },
-      next: { tags: [`maps`] }
+      next: { revalidate: 10 }
     }
   });
 };

--- a/one-day-hero/src/services/missions.ts
+++ b/one-day-hero/src/services/missions.ts
@@ -106,11 +106,11 @@ export const useGetSuggestedMissionListFetch = (
 ) => {
   return useInfiniteFetch<SuggestedMissionListResponse>({
     pathname: `/mission-proposals`,
-    size: 4,
+    size: 10,
     observerRef,
     options: {
       headers: { Authorization: `Bearer ${token}` },
-      next: { tags: [`suggested`] }
+      next: { revalidate: 0 }
     }
   });
 };
@@ -121,7 +121,7 @@ export const useGetProgressMissionListFetch = (
 ) => {
   return useInfiniteFetch<ProgressMissionListResponse>({
     pathname: `/missions/progress`,
-    size: 4,
+    size: 10,
     observerRef,
     options: {
       headers: { Authorization: `Bearer ${token}` },
@@ -140,7 +140,7 @@ export const useGetCompleteMissionListFetch = (
     observerRef,
     options: {
       headers: { Authorization: `Bearer ${token}` },
-      next: { tags: [`complete`] }
+      next: { revalidate: 0 }
     }
   });
 };

--- a/one-day-hero/src/services/notification.ts
+++ b/one-day-hero/src/services/notification.ts
@@ -13,7 +13,7 @@ export const useGetNotificationFetch = (
     observerRef,
     options: {
       headers: { Authorization: `Bearer ${token}` },
-      next: { tags: [`alarms`] }
+      next: { revalidate: 10 }
     }
   });
 };

--- a/one-day-hero/src/services/review.ts
+++ b/one-day-hero/src/services/review.ts
@@ -1,4 +1,3 @@
-import { revalidateTag } from "next/cache";
 import { MutableRefObject } from "react";
 
 import { useInfiniteFetch } from "@/hooks/useInfiniteFetch";
@@ -35,7 +34,8 @@ export const useGetReviewDetailFetch = (reviewId: number, token: string) => {
   return useFetch<ReviewDetailResponse>(`/reviews/${reviewId}`, {
     headers: {
       Authorization: `Bearer ${token}`
-    }
+    },
+    next: { tags: [`review${reviewId}`] }
   });
 };
 
@@ -45,27 +45,24 @@ export const useGetSendReviewFetch = (
 ) => {
   return useInfiniteFetch<ReviewListResponse>({
     pathname: `/me/reviews/send`,
-    size: 5,
+    size: 10,
     options: {
       headers: {
         Authorization: `Bearer ${token}`
-      }
+      },
+      next: { tags: ["reviews"] }
     },
     observerRef
   });
 };
 
 export const useDeleteSendReviewFetch = (reviewId: number) => {
-  return useMutationalFetch<ReviewDeleteResponse>(
-    `/reviews/${reviewId}`,
-    {
-      method: "DELETE",
-      body: JSON.stringify({
-        reviewId
-      })
-    },
-    () => revalidateTag("sendReview")
-  );
+  return useMutationalFetch<ReviewDeleteResponse>(`/reviews/${reviewId}`, {
+    method: "DELETE",
+    body: JSON.stringify({
+      reviewId
+    })
+  });
 };
 
 export const useGetReceiveReviewFetch = (
@@ -75,11 +72,12 @@ export const useGetReceiveReviewFetch = (
 ) => {
   return useInfiniteFetch<ReviewListResponse>({
     pathname: `/reviews/users/${userId}/receive`,
-    size: 5,
+    size: 10,
     options: {
       headers: {
         Authorization: `Bearer ${token}`
-      }
+      },
+      next: { revalidate: 0 }
     },
     observerRef
   });

--- a/one-day-hero/src/services/search.ts
+++ b/one-day-hero/src/services/search.ts
@@ -10,11 +10,11 @@ export const useGetMissionSearchListFetch = (
 ) => {
   return useInfiniteFetch<MissionSearchListResponse>({
     pathname: `/missions`,
-    size: 4,
+    size: 10,
     observerRef,
     options: {
       headers: { Authorization: `Bearer ${token}` },
-      next: { tags: [`missionSearch`] }
+      next: { revalidate: 10 }
     }
   });
 };
@@ -25,11 +25,11 @@ export const useGetHeroNicknameDetailListFetch = (
 ) => {
   return useInfiniteFetch<HeroNicknameSearchResponse>({
     pathname: `/users/hero-search`,
-    size: 3,
+    size: 10,
     observerRef,
     options: {
       headers: { Authorization: `Bearer ${token}` },
-      next: { tags: [`searchHeroNickname`] }
+      next: { revalidate: 10 }
     }
   });
 };

--- a/one-day-hero/src/services/users.ts
+++ b/one-day-hero/src/services/users.ts
@@ -12,7 +12,7 @@ export const useGetProfileFetch = (
     `/users/${userId}/${isHero ? "hero-profile" : "citizen-profile"}`,
     {
       headers: { Authorization: `Bearer ${token}` },
-      next: { tags: [`user${userId}`] }
+      next: { revalidate: 0 }
     }
   );
 };

--- a/one-day-hero/src/types/index.ts
+++ b/one-day-hero/src/types/index.ts
@@ -5,6 +5,7 @@ export type KebabMenuDataType = {
   requiredData?: { name: string; default?: any; options?: any[] }[];
   description?: string;
   redirectTo?: string;
+  refresh?: boolean;
 };
 
 export type ImageFileType = {


### PR DESCRIPTION
## 구현 내용
- 캐시를 전체적으로 정리합니다
  - 다른 사람의 액션으로 변경되는건 모두 revalidation: 0 으로 캐시를 껐습니다.
  - 본인의 액션으로 수정되는 건 tag를 그대로 뒀습니다.
  - 클라에서 포스트 요청 보내는 건 revalidateTag 를 쓰기 힘들어서 route 를 하나 만들어서 서버에 전달합니다.
- 폼 제출 후 push 대신 replace 를 사용합니다.
  - 프로필 작성은 제외
- Tabs 의 동작도 push 였는데 replace로 바꿨습니다.
  - 왔다갔다할 때 이게 더 자연스러울 것 같다고 하더라고요
- form 제출용 route 에서 에러 코드를 body로 전달할 수 있게 했습니다.
  - 상태 코드는 0으로만 오길래 400으로 고정했고 받은 에러메세지를 일단 toast로 띄우게 했습니다.

## 스크린샷

## 궁금한 점

## 이슈번호
- closes #240 
