### PR TITLE
미션 생성시 잘못된 금액 에러 메세지 출력되는 이슈 해결

### DIFF
--- a/one-day-hero/src/components/domain/mission/create/PostCode.tsx
+++ b/one-day-hero/src/components/domain/mission/create/PostCode.tsx
@@ -25,8 +25,8 @@ const PostCode = ({
   const [location, setLocation] = useState<LocationType | null>(
     defaultLocation ?? null
   );
-  const { isOpen, onOpen, onClose } = useModal();
 
+  const { isOpen, onOpen, onClose } = useModal();
   const { showToast } = useToast();
 
   const handleComplete = async (data: { roadAddress: string }) => {
@@ -43,6 +43,7 @@ const PostCode = ({
 
     if (!response.ok) {
       showToast("위치 정보를 찾을 수 없어요", "error");
+
       throw new Error("위치를 제대로 입력해주세요.");
     }
     const res = await response.json();


### PR DESCRIPTION
## 구현 내용
미션 생성시 금액을 입력하지 않았을 시에 "Expected number, received NaN" 에러가 설정한 에러 대신 뜨는 문제 해결했습니다.  MissionFormSchema 의 price 코드를 아래의 코드로 대체했습니다. 

```
 price: z
      .number({ invalid_type_error: "포상금을 입력해 주세요!" })
      .positive("etc.")
      .min(1000, "포상금을 1000원 이상의 값으로 입력해주세요!")
```

> region을 resion으로 실수로 쓰고 계시는 부분이 있길래 한꺼번에 수정했습니다. 

## 스크린샷

https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-FE/assets/99384699/e774d812-2c9e-432a-b896-3dd3ec87d7bd


## 궁금한 점
또 실수로 디벨롭에 바로 수정해 버렸네요... 미안합니다...  변경된 파일이 이 브렌치에 없고 디벨롭으로 바로 올라갔을 거예요.. 

## 이슈번호
- closes #266 
