### PR TITLE
채팅창 엔터 isComposing 처리 추가

### DIFF
--- a/one-day-hero/src/components/common/FooterButton.tsx
+++ b/one-day-hero/src/components/common/FooterButton.tsx
@@ -18,7 +18,7 @@ const FooterButton = ({
   children
 }: PropsWithChildren<FooterButtonProps>) => {
   const defaultStyle =
-    "bg-background shadow-upper flex h-14 max-w-screen-sm w-full items-center justify-center fixed bottom-0";
+    "bg-background shadow-upper flex h-14 max-w-screen-sm w-full items-center justify-center fixed bottom-0 left-0";
 
   return (
     <div className={`${defaultStyle}`}>

--- a/one-day-hero/src/components/common/Info/MissionListItem.tsx
+++ b/one-day-hero/src/components/common/Info/MissionListItem.tsx
@@ -28,7 +28,7 @@ const MissionListItem = ({
   return (
     <div className={`flex w-full ${className}`}>
       <div className="flex grow gap-4">
-        <div className="bg-inactive overflow-hidden rounded-[10px]">
+        <div className="h-[3.75rem] shrink-0 overflow-hidden rounded-[10px] bg-inactive">
           <Image
             src={imageSrc || defaultProfileImage}
             alt="프로필 사진"

--- a/one-day-hero/src/components/common/MissionProgressContainer.tsx
+++ b/one-day-hero/src/components/common/MissionProgressContainer.tsx
@@ -17,7 +17,7 @@ const MissionProgressContainer = ({
   ...props
 }: PropsWithChildren<MissionProgressContainer>) => {
   return (
-    <Container className="cs:w-11/12 cs:p-0">
+    <Container className="cs:w-full cs:p-0">
       {children}
       <MissionProgressBar missionStatus={missionStatus} {...props} />
     </Container>

--- a/one-day-hero/src/components/domain/chatting/ChattingInputFooter.tsx
+++ b/one-day-hero/src/components/domain/chatting/ChattingInputFooter.tsx
@@ -47,6 +47,7 @@ const ChattingInputFooter = ({
           value={inputValue}
           onChange={handleChange}
           onKeyDown={(e) => {
+            if (e.nativeEvent.isComposing) return;
             if (e.key === "Enter") handleSend();
           }}
         />

--- a/one-day-hero/src/components/domain/mission/suggested/SuggestedMissionItem.tsx
+++ b/one-day-hero/src/components/domain/mission/suggested/SuggestedMissionItem.tsx
@@ -103,7 +103,7 @@ const SuggestedMissionItem = ({
       <Link
         href={`/mission/${missionData.id}`}
         className="flex w-full max-w-screen-sm justify-center">
-        <Container className="cs:w-11/12" missionStatus={missionData.status}>
+        <Container className="cs:w-full" missionStatus={missionData.status}>
           <MissionFullInfo
             bookmarkCount={missionData.bookmarkCount}
             region={missionData.region}


### PR DESCRIPTION
## 구현 내용
- 채팅창 input keydown 이벤트에 isComposing 처리를 추가했습니다.
- 테스트 하다가 일부 어색한 스타일도 수정했습니다

## 스크린샷

## 궁금한 점
- 아마 맥에서만 발생하는 이슈 같은데 수정되었는지 확인이 필요합니다.

## 이슈번호
- closes #268 
